### PR TITLE
Feat: inactive users

### DIFF
--- a/pages/users.vue
+++ b/pages/users.vue
@@ -17,10 +17,16 @@
             <b-avatar :src="user.picture" />
           </b-col>
 
-          <b-col cols-md="7">
+          <b-col cols-md="4">
             <div class="font-weight-bold user-row__name my-2">
               {{ user.name }}
             </div>
+          </b-col>
+
+          <b-col cols-md="3" class="d-flex justify-content-end">
+            <b-button @click="toggleActive(user)">
+              {{ user.active ? "Deactivate" : "Activate" }} user
+            </b-button>
           </b-col>
 
           <b-col cols-md="3" class="d-flex justify-content-end">
@@ -44,12 +50,17 @@ export default defineComponent({
     const users = computed(() => store.state.users.users);
     store.dispatch("users/getUsers");
 
+    const toggleActive = (user: User) => {
+      store.dispatch("users/toggleActive", user);
+    };
+
     const toggleTravelAllowance = (user: User) => {
       store.dispatch("users/toggleTravelAllowance", user);
     };
 
     return {
       users,
+      toggleActive,
       toggleTravelAllowance,
     };
   },

--- a/services/users-service.ts
+++ b/services/users-service.ts
@@ -22,10 +22,11 @@ export default class UsersService {
     const doc = await ref.doc(userId).get();
 
     if (doc.exists) {
-      const { name, picture, travelAllowance } = doc.data() as User;
+      const { active, name, picture, travelAllowance } = doc.data() as User;
 
       return {
         id: doc.id,
+        active,
         name,
         picture,
         travelAllowance,
@@ -43,6 +44,7 @@ export default class UsersService {
     const newUser = {
       name: params.name,
       picture: params.picture,
+      active: true,
       travelAllowance: false,
     };
 

--- a/store/reports/mutations.ts
+++ b/store/reports/mutations.ts
@@ -15,11 +15,12 @@ const mutations: MutationTree<ReportsStoreState> = {
     }
   ) {
     const { users, timeRecords, travelRecords } = payload;
+    const activeUsers = users.filter((x) => !!x.active);
     const nonBillableProjects = payload.customers.filter((customer) =>
       customer.debtor.toUpperCase().includes("FRONTMEN")
     );
 
-    const reportUsers = users.map((user) => {
+    const reportUsers = activeUsers.map((user) => {
       const userTimeRecords = timeRecords.filter((x) => x.userId === user.id);
 
       const userTravelRecords = travelRecords.filter(

--- a/store/timesheets/actions.ts
+++ b/store/timesheets/actions.ts
@@ -19,8 +19,9 @@ const actions: ActionTree<TimesheetsStoreState, RootStoreState> = {
     const travelRecords = await this.app.$travelRecordsService.getPendingOrDeniedRecords();
 
     const users = await this.app.$usersService.getUsers();
+    const activeUsers = users.filter((x) => !!x.active);
 
-    const timesheetUsers = users.map((user) => {
+    const timesheetUsers = activeUsers.map((user) => {
       const pendingTimeRecords = timeRecords.filter((record) =>
         isPendingRecord(record, user.id)
       );

--- a/store/users/actions.ts
+++ b/store/users/actions.ts
@@ -6,6 +6,13 @@ const actions: ActionTree<UsersStoreState, RootStoreState> = {
     commit("setUsers", { users });
   },
 
+  async toggleActive({ commit }, payload: User) {
+    const newUser = { ...payload, active: !payload.active };
+    await this.app.$usersService.updateUser(newUser);
+
+    commit("updateUser", { user: newUser });
+  },
+
   async toggleTravelAllowance({ commit }, payload: User) {
     const newUser = { ...payload, travelAllowance: !payload.travelAllowance };
     await this.app.$usersService.updateUser(newUser);

--- a/types/user.d.ts
+++ b/types/user.d.ts
@@ -1,5 +1,6 @@
 interface User {
   id: string;
+  active: boolean;
   name: string;
   picture: string;
   travelAllowance: boolean;


### PR DESCRIPTION
#### What does this PR do?

- Adds `active` field to user objects
- Hides inactive users in `timesheets` and `reports` pages.

#### Why are we doing this? Any context or related work?

resolves #20 