### PR TITLE
Feat: unsubmit timesheet

### DIFF
--- a/components/records/weekly-timesheet-footer.vue
+++ b/components/records/weekly-timesheet-footer.vue
@@ -2,14 +2,24 @@
   <div class="weekly-timesheet-footer">
     <div>
       <span v-if="lastSaved">Last saved: {{ lastSavedLabel }}</span>
+      <b-spinner v-if="isSaving" small />
 
       <b-button
+        v-if="canSubmitForApproval"
         class="mx-3"
-        :disabled="(isSaving || !hasUnsavedChanges) && !canSubmitForApproval"
+        :disabled="isSaving || !hasUnsavedChanges"
         @click="handleSaveClick"
       >
-        <b-spinner v-if="isSaving" small />
         Save
+      </b-button>
+
+      <b-button
+        v-if="canUnsubmitForApproval"
+        class="mx-3"
+        :disabled="isSaving"
+        @click="handleUnsubmitClick"
+      >
+        Unsubmit
       </b-button>
     </div>
 
@@ -35,7 +45,7 @@ import { formatDistanceToNow } from "date-fns";
 import { recordStatus } from "~/helpers/record-status";
 
 export default defineComponent({
-  emits: ["approve", "save"],
+  emits: ["submit", "save", "unsubmit"],
   props: {
     hasUnsavedChanges: {
       type: Boolean,
@@ -60,6 +70,7 @@ export default defineComponent({
 
     const handleSaveClick = () => emit("save");
     const handleSubmitClick = () => emit("submit");
+    const handleUnsubmitClick = () => emit("unsubmit");
 
     const submitButtonLabel = computed(() => {
       switch (props.status) {
@@ -78,6 +89,10 @@ export default defineComponent({
       () =>
         props.status === recordStatus.NEW ||
         props.status === recordStatus.DENIED
+    );
+
+    const canUnsubmitForApproval = computed(
+      () => props.status === recordStatus.PENDING
     );
 
     const updateLastSavedLabel = () => {
@@ -102,8 +117,10 @@ export default defineComponent({
     return {
       handleSaveClick,
       handleSubmitClick,
+      handleUnsubmitClick,
       submitButtonLabel,
       canSubmitForApproval,
+      canUnsubmitForApproval,
       lastSavedLabel,
     };
   },

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -64,6 +64,7 @@
         :status="timesheet.status"
         @save="saveTimesheet"
         @submit="submitTimesheet"
+        @unsubmit="saveTimesheet"
       />
     </template>
 
@@ -217,6 +218,8 @@ export default defineComponent({
         timesheet: timesheet.value,
         status: recordStatus.PENDING as RecordStatus,
       });
+
+      hasUnsavedChanges.value = false;
     };
 
     return {


### PR DESCRIPTION
#### What does this PR do?

Allows the user to `unsubmit` the timesheet so they can edit it again.

#### Why are we doing this? Any context or related work?

resolves #17 