### PR TITLE
feat: ask confirmation when switching week with unsaved changes

### DIFF
--- a/pages/records.vue
+++ b/pages/records.vue
@@ -138,9 +138,6 @@ export default defineComponent({
       ];
     });
 
-    const goToWeek = (to: "current" | "previous" | "next") =>
-      store.dispatch("records/goToWeek", { to });
-
     const hasUnsavedChanges = ref<Boolean>(false);
     const timesheet = ref<WeeklyTimesheet>({
       isReadonly: false,
@@ -148,6 +145,18 @@ export default defineComponent({
       projects: [],
       travelProject: null,
     });
+
+    const goToWeek = (to: "current" | "previous" | "next") => {
+      if (hasUnsavedChanges.value) {
+        const confirmation = confirm(
+          "You have unsaved changes, are you sure you want to switch to another week?"
+        );
+
+        if (!confirmation) return;
+      }
+
+      store.dispatch("records/goToWeek", { to });
+    };
 
     const addProject = (id: string) => {
       const allCustomers = store.state.customers.customers;
@@ -192,6 +201,8 @@ export default defineComponent({
         recordsState.value.travelRecords,
       ],
       () => {
+        hasUnsavedChanges.value = false;
+
         timesheet.value = createWeeklyTimesheet({
           week: recordsState.value.selectedWeek,
           timeRecords: recordsState.value.timeRecords,


### PR DESCRIPTION
#### What does this PR do?

As we want to avoid writing too much documents, we're not auto-saving on input. This could be annoying when switching weeks without saving, so we show a confirmation dialog before switching week when the user has unsaved changes.

#### Why are we doing this? Any context or related work?

resolves #21 