### PR TITLE
feat: disabled workscheme logic

### DIFF
--- a/components/records/weekly-timesheet-totals-row.vue
+++ b/components/records/weekly-timesheet-totals-row.vue
@@ -10,26 +10,23 @@
       </b-button>
     </b-col>
 
+    <!-- TODO: use classes and show {{ value / dayTheoraticalTotals[index] }} when `workSchem` API is implemented -->
     <b-col
       v-for="(value, index) in dayTotals"
       :key="index"
       cols="1"
       class="weekly-timesheet-totals-row__column"
-      :class="{
-        exceeded: value > dayTheoreticalHours[index],
-        valid: value === dayTheoreticalHours[index],
-      }"
     >
-      <span>{{ value }}/{{ dayTheoreticalHours[index] }}</span>
+      <span>{{ value }}</span>
     </b-col>
 
+    <!-- TODO: use classes and show {{ weekTotal / weekTheoraticalTotal }} when `workSchem` API is implemented -->
     <b-col
       cols="1"
       class="weekly-timesheet-totals-row__week-column d-none d-sm-block"
-      :class="{ exceeded: weekTotal > weekTheoreticalTotal }"
     >
       <span>
-        <strong> {{ weekTotal }}/{{ weekTheoreticalTotal }} </strong>
+        <strong>{{ weekTotal }}</strong>
       </span>
     </b-col>
   </b-row>

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -48,12 +48,19 @@ const createTimesheetProjects = (
   const projects: TimesheetProject[] = [];
 
   const customerProjects = createCustomerProjects(week, customers, timeRecords);
+
+  // TODO: enable this when the `workScheme` api has been implemented
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   const leaveProject = createLeaveProject(workScheme);
+  // TODO: enable this when the `workScheme` api has been implemented
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
   const absenceProject = createAbsceneProject(workScheme);
 
   if (customerProjects.length > 0) projects.push(...customerProjects);
-  if (leaveProject) projects.push(leaveProject);
-  if (absenceProject) projects.push(absenceProject);
+  // TODO: enable this when the `workScheme` api has been implemented
+  // if (leaveProject) projects.push(leaveProject);
+  // TODO: enable this when the `workScheme` api has been implemented
+  // if (absenceProject) projects.push(absenceProject);
 
   return projects;
 };


### PR DESCRIPTION
#### What does this PR do?

Makes the `leave` and `absence` projects editable again, like other projects. I kept the logic in place for when the API is implemented.

#### Why are we doing this? Any context or related work?

resolves #22 

---

### OTHER

Related to #9 