### PR TITLE
fix: dont copy weekly status from previous week

### DIFF
--- a/components/records/weekly-timesheet-footer.vue
+++ b/components/records/weekly-timesheet-footer.vue
@@ -6,7 +6,7 @@
 
       <b-button
         v-if="canSubmitForApproval"
-        class="mx-3"
+        class="ml-3"
         :disabled="isSaving || !hasUnsavedChanges"
         @click="handleSaveClick"
       >
@@ -15,7 +15,7 @@
 
       <b-button
         v-if="canUnsubmitForApproval"
-        class="mx-3"
+        class="ml-3"
         :disabled="isSaving"
         @click="handleUnsubmitClick"
       >
@@ -24,6 +24,7 @@
     </div>
 
     <b-button
+      class="ml-3"
       :disabled="isSaving || !canSubmitForApproval"
       @click="handleSubmitClick"
     >

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -6,6 +6,7 @@ export const createWeeklyTimesheet = (params: {
   timeRecords: TimeRecord[];
   travelRecords: TravelRecord[];
   workScheme: WorkScheme[];
+  status?: RecordStatus;
 }): WeeklyTimesheet => {
   const start = new Date(params.week[0].date);
   const end = new Date(params.week[6].date);
@@ -16,7 +17,7 @@ export const createWeeklyTimesheet = (params: {
   const weeklyCustomers: Customer[] = [];
   const weeklyTimeRecords = params.timeRecords.filter(isWithinCurrentWeek);
   const weeklyTravelRecords = params.travelRecords.filter(isWithinCurrentWeek);
-  const weeklyStatus = getWeeklyStatus(weeklyTimeRecords);
+  const weeklyStatus = params.status || getWeeklyStatus(weeklyTimeRecords);
 
   weeklyTimeRecords.forEach((timeRecord) => {
     if (!weeklyCustomers.some((x) => x.id === timeRecord.customer.id)) {

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -191,6 +191,7 @@ export default defineComponent({
         timeRecords: recordsState.value.timeRecords,
         travelRecords: recordsState.value.travelRecords,
         workScheme: recordsState.value.workScheme,
+        status: recordStatus.NEW as RecordStatus,
       });
 
       hasUnsavedChanges.value = true;


### PR DESCRIPTION
#### What does this PR do?

When copying a previous week which was already `submitted` or `approved` it would use this status for the new week as well. It's setting the status to `NEW` for the newly copied week.