### PR TITLE
feat: add debtor to reports

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Changes
+
+## Related issues
+
+<!--- Add link to issue  -->
+
+## Added
+
+<!--- What is new on this code? -->
+
+## Removed
+
+<!--- What was removed? -->
+
+## Changed
+
+<!--- What has been changed? -->
+
+## How to test
+
+<!--- Add some steps or scenarios of how to test and validate these changes -->
+
+## Screenshots
+
+<!--- In case of any visual changes, add some screenshots here -->

--- a/composables/useMonthlyProjectsReport.ts
+++ b/composables/useMonthlyProjectsReport.ts
@@ -5,6 +5,7 @@ export default () => {
     return [
       { key: "name", sortable: true },
       { key: "project", sortable: true },
+      { key: "debtor", sortable: true },
       { key: "billable", sortable: true, variant: "success" },
     ];
   };
@@ -21,6 +22,7 @@ export default () => {
       name: user.name,
       billable: getTotalHours(records) || 0,
       project: customer.name,
+      debtor: customer.debtor,
     };
   };
 


### PR DESCRIPTION
# Changes

## Related issues

- Resolves #59 

## Added

- Add GitHub PR template

## Removed

N/A

## Changed

- Add debtor column to the Projects timesheet on reports

## How to test

- Go to the Projects tab on /reports and check if we have a Debtor column

## Screenshots

![Screen Shot 2021-04-20 at 11 50 45 (1)](https://user-images.githubusercontent.com/45885054/115418157-a5fc2700-a1cf-11eb-922c-8250c91e763f.png)

