### PR TITLE
feat(employees): add actions to detail page

### DIFF
--- a/pages/employees/_employee_id.vue
+++ b/pages/employees/_employee_id.vue
@@ -6,16 +6,40 @@
       <div v-else>
         <employee-header :employee="employee" />
 
-        <b-form-checkbox-group
-          v-model="selectedCustomers"
-          :options="customerOptions"
-          class="my-3"
-          value-field="item"
-          text-field="name"
-          switches
-          stacked
-          @change="hasUnsavedChanges = true"
-        />
+        <b-row class="my-5">
+          <b-col cols="12" md="6">
+            <h6 class="mb-3">Manage Projects</h6>
+            <b-form-checkbox-group
+              v-model="selectedCustomers"
+              :options="customerOptions"
+              value-field="item"
+              text-field="name"
+              switches
+              stacked
+              @change="hasUnsavedChanges = true"
+            />
+          </b-col>
+
+          <b-col cols="12" md="6">
+            <h6 class="mb-3">Employee Settings</h6>
+            <b-form-checkbox
+              v-model="isTravelAllowed"
+              name="check-button"
+              switch
+              @change="hasUnsavedChanges = true"
+            >
+              Travel allowance
+            </b-form-checkbox>
+            <b-form-checkbox
+              v-model="isEmployeeActive"
+              name="check-button"
+              switch
+              @change="hasUnsavedChanges = true"
+            >
+              Active employee
+            </b-form-checkbox>
+          </b-col>
+        </b-row>
 
         <b-button :disabled="!hasUnsavedChanges" @click="saveProjects">
           Save
@@ -84,11 +108,35 @@ export default defineComponent({
       { immediate: true }
     );
 
+    const isTravelAllowed = ref<boolean>(!!employee.value?.travelAllowance);
+    watch(
+      () => employee.value?.travelAllowance,
+      () => {
+        isTravelAllowed.value = !!employee.value?.travelAllowance;
+      },
+      { immediate: true }
+    );
+
+    const isEmployeeActive = ref<boolean>(!!employee.value?.active);
+    watch(
+      () => employee.value?.active,
+      () => {
+        isEmployeeActive.value = !!employee.value?.active;
+      },
+      { immediate: true }
+    );
+
     const saveProjects = () => {
-      store.dispatch("employees/saveProjects", {
-        employee: employee.value,
-        customerIds: selectedCustomers.value,
-      });
+      if (!employee.value) return;
+
+      const newEmployee = {
+        ...employee.value,
+        projects: selectedCustomers.value,
+        travelAllowance: isTravelAllowed.value,
+        active: isEmployeeActive.value,
+      };
+
+      store.dispatch("employees/updateEmployee", newEmployee);
 
       hasUnsavedChanges.value = false;
     };
@@ -99,6 +147,8 @@ export default defineComponent({
       selectedCustomers,
       saveProjects,
       hasUnsavedChanges,
+      isTravelAllowed,
+      isEmployeeActive,
     };
   },
 });

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -11,37 +11,21 @@
         <b-row
           v-for="employee in employees"
           :key="employee.id"
-          class="app-table__row employee-row py-3"
+          class="app-table__row employee-row p-3 mr-0"
         >
-          <b-col cols="0" class="ml-3">
-            <b-avatar :src="employee.picture" />
-          </b-col>
+          <b-avatar :src="employee.picture" />
 
-          <b-col cols="4">
-            <div class="font-weight-bold employee-row__name my-2">
-              {{ employee.name }}
-            </div>
-          </b-col>
+          <div class="font-weight-bold employee-row__name my-2 mx-3">
+            {{ employee.name }}
+          </div>
 
-          <b-col cols="7" class="d-flex justify-content-end">
-            <template v-if="employee.active">
-              <b-button variant="info" @click="openEmployeePage(employee)">
-                Manage projects
-              </b-button>
-
-              <b-button class="mx-2" @click="toggleTravelAllowance(employee)">
-                {{ employee.travelAllowance ? "Disable" : "Enable" }} travel
-                allowance
-              </b-button>
-            </template>
-
-            <b-button
-              :variant="employee.active ? 'warning' : 'danger'"
-              @click="toggleActive(employee)"
-            >
-              {{ employee.active ? "Deactivate" : "Activate" }} employee
-            </b-button>
-          </b-col>
+          <b-button
+            variant="info"
+            class="ml-auto"
+            @click="openEmployeePage(employee)"
+          >
+            Manage employee
+          </b-button>
         </b-row>
       </b-container>
     </div>
@@ -69,22 +53,12 @@ export default defineComponent({
     const employees = computed(() => store.state.employees.employees);
     store.dispatch("employees/getEmployees");
 
-    const toggleActive = (employee: Employee) => {
-      store.dispatch("employees/toggleActive", employee);
-    };
-
-    const toggleTravelAllowance = (employee: Employee) => {
-      store.dispatch("employees/toggleTravelAllowance", employee);
-    };
-
     const openEmployeePage = (employee: Employee) => {
       router.push(`employees/${employee.id}`);
     };
 
     return {
       employees,
-      toggleActive,
-      toggleTravelAllowance,
       openEmployeePage,
     };
   },

--- a/store/employees/actions.ts
+++ b/store/employees/actions.ts
@@ -6,23 +6,6 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
     commit("setEmployees", { employees });
   },
 
-  async toggleActive({ commit }, payload: Employee) {
-    const newEmployee = { ...payload, active: !payload.active };
-    await this.app.$EmployeesService.updateEmployee(newEmployee);
-
-    commit("updateEmployee", { employee: newEmployee });
-  },
-
-  async toggleTravelAllowance({ commit }, payload: Employee) {
-    const newEmployee = {
-      ...payload,
-      travelAllowance: !payload.travelAllowance,
-    };
-    await this.app.$employeesService.updateEmployee(newEmployee);
-
-    commit("updateEmployee", { employee: newEmployee });
-  },
-
   async saveProjects(
     { commit },
     payload: { employee: Employee; customerIds: string[] }
@@ -31,6 +14,11 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
     await this.app.$employeesService.updateEmployee(newEmployee);
 
     commit("updateEmployee", { employee: newEmployee });
+  },
+
+  async updateEmployee({ commit }, payload: Employee) {
+    await this.app.$employeesService.updateEmployee(payload);
+    commit("updateEmployee", { employee: payload });
   },
 };
 


### PR DESCRIPTION
# Changes

## Related issues

Resolves #54 

## Added

- `employees/updateEmployee` action

## Removed

- `employees/toggleActive` action
- `employees/toggleTravelAllowance` action

## Changed

- Employee controls are now on the employee detail page

## How to test

- Navigate to the employee detail page (Click on the "Manage employee" button on the employee page )
- Try to change the employee data toggling the switches
- The changes should only be saved after clicking the "Save" button.

## Screenshots

- Employees page

![Screen Shot 2021-04-27 at 19 03 45 (1)](https://user-images.githubusercontent.com/45885054/116319123-52b84480-a78c-11eb-8df2-0643b6ca7a5b.png)

- Employee detail page

![Screen Shot 2021-04-27 at 19 10 37 (1)](https://user-images.githubusercontent.com/45885054/116319185-724f6d00-a78c-11eb-8d24-b54788ff5e99.png)

