### PR TITLE
Feat: employee end date

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -32,10 +32,8 @@
         :formatter="valueFormatter.formatter"
         :min="valueFormatter.min"
         :max="valueFormatter.max"
-        :readonly="checkIfReadonly(selectedWeek[index].date)"
-        @focus.native="
-          handleInputFocus($event.target, selectedWeek[index].date)
-        "
+        :readonly="isReadonlyList[index]"
+        @focus.native="handleInputFocus($event.target, index)"
         @input="$emit('change')"
       />
     </b-col>
@@ -88,20 +86,24 @@ export default defineComponent({
       props.project.values.reduce((total, current) => total + current)
     );
 
-    const checkIfReadonly = (paramDate: string) => {
-      if (props.readonly) {
-        return true;
-      }
+    // An array of booleans, one for each day of the selected week, that states
+    // if the input for that respective day is readonly or not.
+    const isReadonlyList = computed(() =>
+      props.selectedWeek.map((day) => {
+        if (props.readonly) {
+          return true;
+        }
 
-      const isEmployeeActive = props.employee.endDate
-        ? checkEmployeeAvailability(props.employee, new Date(paramDate))
-        : false;
+        const isEmployeeActive = props.employee.endDate
+          ? checkEmployeeAvailability(props.employee, new Date(day.date))
+          : false;
 
-      return !isEmployeeActive;
-    };
+        return !isEmployeeActive;
+      })
+    );
 
-    const handleInputFocus = ($input: HTMLInputElement, paramDate: string) => {
-      if (!checkIfReadonly(paramDate)) {
+    const handleInputFocus = ($input: HTMLInputElement, dayIndex: number) => {
+      if (!isReadonlyList.value[dayIndex]) {
         $input.select();
       }
     };
@@ -110,7 +112,7 @@ export default defineComponent({
       canRemove,
       handleRemoveClick,
       totalValue,
-      checkIfReadonly,
+      isReadonlyList,
       handleInputFocus,
     };
   },

--- a/components/timesheets/timesheet-employee-row.vue
+++ b/components/timesheets/timesheet-employee-row.vue
@@ -10,7 +10,7 @@
 
     <b-col>
       <div class="font-weight-bold">
-        {{ employee.name }}
+        {{ employee.name }} {{ employee.endDate ? "(Inactive)" : "" }}
       </div>
 
       <div v-if="employee.status === recordStatus.NEW" class="text-success">

--- a/components/timesheets/timesheet-employee-row.vue
+++ b/components/timesheets/timesheet-employee-row.vue
@@ -10,7 +10,7 @@
 
     <b-col>
       <div class="font-weight-bold">
-        {{ employee.name }} {{ employee.endDate ? "(Inactive)" : "" }}
+        {{ displayName }}
       </div>
 
       <div v-if="employee.status === recordStatus.NEW" class="text-success">
@@ -29,7 +29,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType } from "@nuxtjs/composition-api";
+import { computed, defineComponent, PropType } from "@nuxtjs/composition-api";
 import { recordStatus } from "~/helpers/record-status";
 
 export default defineComponent({
@@ -40,12 +40,18 @@ export default defineComponent({
       required: true,
     },
   },
-  setup(_, { emit }) {
+  setup(props, { emit }) {
     const handleClick = () => emit("click");
+
+    const displayName = computed(
+      () =>
+        `${props.employee.name}${props.employee.endDate ? " (Inactive)" : ""}`
+    );
 
     return {
       handleClick,
       recordStatus,
+      displayName,
     };
   },
 });

--- a/helpers/employee.ts
+++ b/helpers/employee.ts
@@ -1,0 +1,8 @@
+import isAfter from "date-fns/isAfter";
+
+export function checkEmployeeAvailability(
+  employee: Employee,
+  compareDate: Date
+) {
+  return !employee.endDate || isAfter(new Date(employee.endDate), compareDate);
+}

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -244,3 +244,34 @@ export const getTravelRecordsToSave = (
 
   return travelRecordsToSave;
 };
+
+const scoringTimesheetEmployee = (timesheetEmployee: TimesheetEmployee) => {
+  let score = 0;
+
+  if (timesheetEmployee.status === recordStatus.PENDING) {
+    score = 100000;
+  } else if (timesheetEmployee.status === recordStatus.DENIED) {
+    score = 1000;
+  } else {
+    score = 10;
+  }
+
+  if (!timesheetEmployee.endDate) {
+    score *= 1.1;
+  }
+
+  return score;
+};
+
+// Compare TimesheetEmployees to sort then to show from top to bottom:
+// PENDING > DENIED > NEW
+// Inactive employees will be the last of each block
+export const compareTimesheetEmployees = (
+  prevEmployee: TimesheetEmployee,
+  nextEmployee: TimesheetEmployee
+) => {
+  const prevScore = scoringTimesheetEmployee(prevEmployee);
+  const nextScore = scoringTimesheetEmployee(nextEmployee);
+
+  return nextScore - prevScore;
+};

--- a/pages/employees/_employee_id.vue
+++ b/pages/employees/_employee_id.vue
@@ -117,11 +117,11 @@ export default defineComponent({
       { immediate: true }
     );
 
-    const isEmployeeActive = ref<boolean>(!!employee.value?.active);
+    const isEmployeeActive = ref<boolean>(!employee.value?.endDate);
     watch(
-      () => employee.value?.active,
+      () => employee.value?.endDate,
       () => {
-        isEmployeeActive.value = !!employee.value?.active;
+        isEmployeeActive.value = !employee.value?.endDate;
       },
       { immediate: true }
     );
@@ -133,8 +133,18 @@ export default defineComponent({
         ...employee.value,
         projects: selectedCustomers.value,
         travelAllowance: isTravelAllowed.value,
-        active: isEmployeeActive.value,
       };
+
+      const hasActivationChanged =
+        !!employee.value.endDate === isEmployeeActive.value;
+
+      if (hasActivationChanged && !isEmployeeActive.value) {
+        newEmployee.endDate = new Date().getTime();
+      }
+
+      if (hasActivationChanged && isEmployeeActive.value) {
+        newEmployee.endDate = null;
+      }
 
       store.dispatch("employees/updateEmployee", newEmployee);
 

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -35,6 +35,7 @@
             "
             :selected-week="recordsState.selectedWeek"
             :value-formatter="timesheetFormatter"
+            :employee="employee"
             @change="hasUnsavedChanges = true"
             @remove="deleteProject(timesheet.projects[index])"
           />
@@ -63,6 +64,7 @@
               :removable="false"
               :selected-week="recordsState.selectedWeek"
               :value-formatter="kilometerFormatter"
+              :employee="employee"
               @change="hasUnsavedChanges = true"
             />
           </template>

--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -23,7 +23,6 @@ export default class EmployeesService {
 
     if (doc.exists) {
       const {
-        active,
         name,
         picture,
         projects,
@@ -33,7 +32,6 @@ export default class EmployeesService {
 
       return {
         id: doc.id,
-        active,
         name,
         picture,
         projects,

--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -28,6 +28,7 @@ export default class EmployeesService {
         picture,
         projects,
         travelAllowance,
+        endDate,
       } = doc.data() as Employee;
 
       return {
@@ -37,6 +38,7 @@ export default class EmployeesService {
         picture,
         projects,
         travelAllowance,
+        endDate,
       };
     }
 
@@ -52,8 +54,8 @@ export default class EmployeesService {
       name: params.name,
       picture: params.picture,
       projects: [],
-      active: true,
       travelAllowance: false,
+      endDate: null,
     };
 
     const ref = this.fire.firestore.collection("employees");

--- a/store/reports/actions.ts
+++ b/store/reports/actions.ts
@@ -1,5 +1,7 @@
-import { startOfMonth, lastDayOfMonth, isBefore } from "date-fns";
+import { startOfMonth, lastDayOfMonth } from "date-fns";
 import { ActionTree } from "vuex";
+
+import { checkEmployeeAvailability } from "../../helpers/employee";
 
 const actions: ActionTree<ReportsStoreState, RootStoreState> = {
   async getMonthlyReportData({ commit }, payload: { startDate: Date }) {
@@ -10,9 +12,8 @@ const actions: ActionTree<ReportsStoreState, RootStoreState> = {
 
     const customers = await this.app.$customersService.getCustomers();
     const employees: Employee[] = await this.app.$employeesService.getEmployees();
-    const activeEmployees = employees.filter(
-      (employee) =>
-        !employee.endDate || !isBefore(new Date(employee.endDate), startDate)
+    const activeEmployees = employees.filter((employee) =>
+      checkEmployeeAvailability(employee, startDate)
     );
 
     const timeRecords = await this.app.$timeRecordsService.getApprovedRecords({

--- a/store/reports/actions.ts
+++ b/store/reports/actions.ts
@@ -1,4 +1,4 @@
-import { startOfMonth, lastDayOfMonth } from "date-fns";
+import { startOfMonth, lastDayOfMonth, isBefore } from "date-fns";
 import { ActionTree } from "vuex";
 
 const actions: ActionTree<ReportsStoreState, RootStoreState> = {
@@ -9,7 +9,11 @@ const actions: ActionTree<ReportsStoreState, RootStoreState> = {
     const endDate = lastDayOfMonth(payload.startDate);
 
     const customers = await this.app.$customersService.getCustomers();
-    const employees = await this.app.$employeesService.getEmployees(); // TODO: should filter on `active` employees
+    const employees: Employee[] = await this.app.$employeesService.getEmployees();
+    const activeEmployees = employees.filter(
+      (employee) =>
+        !employee.endDate || !isBefore(new Date(employee.endDate), startDate)
+    );
 
     const timeRecords = await this.app.$timeRecordsService.getApprovedRecords({
       startDate,
@@ -25,7 +29,7 @@ const actions: ActionTree<ReportsStoreState, RootStoreState> = {
 
     commit("setIsLoading", { isLoading: false });
     commit("createMonthlyReportData", {
-      employees,
+      employees: activeEmployees,
       customers,
       timeRecords,
       travelRecords,

--- a/store/reports/mutations.ts
+++ b/store/reports/mutations.ts
@@ -15,12 +15,11 @@ const mutations: MutationTree<ReportsStoreState> = {
     }
   ) {
     const { employees, timeRecords, travelRecords } = payload;
-    const activeEmployees = employees.filter((x) => x.active);
     const nonBillableProjects = payload.customers.filter(
       (customer) => !customer.isBillable
     );
 
-    const reportEmployees = activeEmployees.map((employee) => {
+    const reportEmployees = employees.map((employee) => {
       const employeeTimeRecords = timeRecords.filter(
         (x) => x.employeeId === employee.id
       );

--- a/types/employee.d.ts
+++ b/types/employee.d.ts
@@ -1,10 +1,11 @@
 interface Employee {
   id: string;
-  active: boolean;
+  active?: boolean;
   name: string;
   picture: string;
   travelAllowance: boolean;
   projects: string[];
+  endDate: number | null;
 }
 
 interface EmployeeStoreState {

--- a/types/employee.d.ts
+++ b/types/employee.d.ts
@@ -1,6 +1,5 @@
 interface Employee {
   id: string;
-  active?: boolean;
   name: string;
   picture: string;
   travelAllowance: boolean;


### PR DESCRIPTION
# Changes

## Related issues

Resolves #49 

## Added

- Now on the timesheet page the employees are sorted by status
- End date field on the employee schema

## Removed

- Active field on the employee schema

## Changed

- We check if the employee is active or not per date, using the endDate prop
- Input value is selected when focused on editable timesheets

## How to test

- Check if inactive employees are showing on reports of past dates when they were still active
- Check if employees are sorted by status (PENDING, DENIED, and NEW) on the timesheets page
- The employee should still be able to add hours to dates when he was still active

## Screenshots

N/A
