### PR TITLE
fix: adjust isReadonlyList logic

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -96,7 +96,7 @@ export default defineComponent({
 
         const isEmployeeActive = props.employee.endDate
           ? checkEmployeeAvailability(props.employee, new Date(day.date))
-          : false;
+          : true;
 
         return !isEmployeeActive;
       })


### PR DESCRIPTION
# Changes

## Related issues

N/A

## Added

N/A

## Removed

N/A

## Changed

- Return the correct boolean value when the employee has an end date

## How to test

- Check if you can correctly edit the record inputs before the employee end date

## Screenshots

N/A
