### PR TITLE
Feat: add timezone support

### DIFF
--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -28,7 +28,7 @@
 import { computed, defineComponent, PropType } from "@nuxtjs/composition-api";
 import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
 
-import { getWeekRange, getDateLabel } from "~/helpers/dates";
+import { getWeekRange, getDateLabel, getDayOnGMT } from "~/helpers/dates";
 
 export default defineComponent({
   emits: ["previous", "next", "current"],
@@ -56,7 +56,7 @@ export default defineComponent({
       if (!props.selectedWeek.length) return 0;
 
       const today = new Date();
-      const startDate = new Date(props.selectedWeek[0].date);
+      const startDate = getDayOnGMT(props.selectedWeek[0].date);
 
       return differenceInCalendarWeeks(startDate, today, { weekStartsOn: 1 });
     });

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -1,7 +1,7 @@
 import { computed, useStore, ref, watch } from "@nuxtjs/composition-api";
 import { startOfISOWeek, subDays } from "date-fns";
 
-import { buildWeek } from "~/helpers/dates";
+import { buildWeek, getDayOnGMT } from "~/helpers/dates";
 import { recordStatus } from "~/helpers/record-status";
 import {
   createWeeklyTimesheet,
@@ -31,7 +31,7 @@ export default (employeeId: string, startTimestamp?: number) => {
     travelProject: null,
   });
 
-  const initialDate = startTimestamp ? new Date(startTimestamp) : new Date();
+  const initialDate = startTimestamp ? getDayOnGMT(startTimestamp) : new Date();
 
   store.dispatch("records/getRecords", {
     employeeId,

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -1,6 +1,5 @@
 import {
   format,
-  formatISO,
   isToday,
   isWeekend,
   isSameDay,
@@ -75,12 +74,6 @@ export function getWeekRange(beginDate: string) {
   return { start, end };
 }
 
-// Get ISO date string with the format "YYYY-MM-DD" on the GMT time, so we can
-// easily check for date equality wihout worrying abou hours or timezone differences
-export function getISODay(date: number | Date) {
-  return formatISO(date).slice(0, 10);
-}
-
 function buildWeekSpan(startDate: Date) {
   const start = startOfISOWeek(startDate);
   const end = addDays(start, 6);
@@ -89,12 +82,12 @@ function buildWeekSpan(startDate: Date) {
     start: {
       date: start.getTime(),
       formatedDate: format(start, "dd/MMM"),
-      ISO: getISODay(start),
+      ISO: formatDate(start),
     },
     end: {
       date: end.getTime(),
       formatedDate: format(end, "dd/MMM"),
-      ISO: getISODay(end),
+      ISO: formatDate(end),
     },
   };
 }

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -70,9 +70,9 @@ export function buildWeek(
 // return in this format so its usable for date-fns, which need the js new Date object.
 // wrap it in the format function to get rid of the hours
 export function getWeekRange(beginDate: string) {
-  const start = startOfISOWeek(new Date(beginDate));
+  const start = startOfISOWeek(getDayOnGMT(beginDate));
   const end = addDays(start, 6);
-  return { start: new Date(formatDate(start)), end: new Date(formatDate(end)) };
+  return { start, end };
 }
 
 // Get ISO date string with the format "YYYY-MM-DD" on the GMT time, so we can
@@ -117,4 +117,16 @@ export function getWeeksSpan(
   });
 
   return weeksSpan;
+}
+
+// Due to timezones, the timestamps or other date formats can be referencing the wrong day.
+// To guarantee that we are always referencing to the same date, we use GMT as a standard.
+// This function will adjust the date to the correct day.
+export function getDayOnGMT(initialZonedValue: Date | number | string) {
+  const MILLISECONDS_IN_MINUTES = 60000;
+  const zonedDate = new Date(initialZonedValue);
+  return new Date(
+    zonedDate.getTime() +
+      zonedDate.getTimezoneOffset() * MILLISECONDS_IN_MINUTES
+  );
 }

--- a/helpers/record-status.ts
+++ b/helpers/record-status.ts
@@ -1,5 +1,7 @@
 import { isSameISOWeek } from "date-fns";
 
+import { getDayOnGMT } from "./dates";
+
 export const recordStatus = {
   NEW: "new",
   PENDING: "pending",
@@ -16,7 +18,7 @@ export function filterApprovedRecords<T extends TimeRecord | TravelRecord>(
     const recordTimesheet = timesheets.find(
       (timesheet) =>
         record.employeeId === timesheet.employeeId &&
-        isSameISOWeek(record.date, timesheet.date)
+        isSameISOWeek(getDayOnGMT(record.date), getDayOnGMT(timesheet.date))
     );
 
     if (recordTimesheet && recordTimesheet.status === recordStatus.APPROVED) {

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -1,7 +1,7 @@
 import { isSameDay, isWithinInterval } from "date-fns";
 
 import { recordStatus } from "./record-status";
-import { getISODay } from "./dates";
+import { getDayOnGMT, formatDate } from "./dates";
 
 export const createWeeklyTimesheet = (params: {
   week: WeekDate[];
@@ -224,37 +224,6 @@ export const getTravelRecordsToSave = (
   return travelRecordsToSave;
 };
 
-const scoringTimesheetEmployee = (timesheetEmployee: TimesheetEmployee) => {
-  let score = 0;
-
-  if (timesheetEmployee.status === recordStatus.PENDING) {
-    score = 100000;
-  } else if (timesheetEmployee.status === recordStatus.DENIED) {
-    score = 1000;
-  } else {
-    score = 10;
-  }
-
-  if (!timesheetEmployee.endDate) {
-    score *= 1.1;
-  }
-
-  return score;
-};
-
-// Compare TimesheetEmployees to sort then to show from top to bottom:
-// PENDING > DENIED > NEW
-// Inactive employees will be the last of each block
-export const compareTimesheetEmployees = (
-  prevEmployee: TimesheetEmployee,
-  nextEmployee: TimesheetEmployee
-) => {
-  const prevScore = scoringTimesheetEmployee(prevEmployee);
-  const nextScore = scoringTimesheetEmployee(nextEmployee);
-
-  return nextScore - prevScore;
-};
-
 export const createTimesheetTableData = (params: {
   employees: Employee[];
   timesheets: Timesheet[];
@@ -278,7 +247,7 @@ export const createTimesheetTableData = (params: {
   items.forEach((item) => {
     timesheets.forEach((timesheet) => {
       if (item.id === timesheet.employeeId) {
-        item[getISODay(timesheet.date)] = timesheet.status;
+        item[formatDate(getDayOnGMT(timesheet.date))] = timesheet.status;
       }
     });
   });

--- a/pages/holidays.vue
+++ b/pages/holidays.vue
@@ -55,7 +55,6 @@ import {
   ref,
   useStore,
 } from "@nuxtjs/composition-api";
-import { formatISO, isSameDay } from "date-fns";
 
 export default defineComponent({
   middleware: ["isAdmin"],
@@ -71,19 +70,22 @@ export default defineComponent({
     const newHolidayValue = ref("");
 
     const addHoliday = () => {
-      const holidayDate = formatISO(new Date(newHolidayValue.value));
-      store.dispatch("holidays/addHoliday", holidayDate);
+      if (!newHolidayValue.value) return;
+
+      store.dispatch("holidays/addHoliday", newHolidayValue.value);
       newHolidayValue.value = "";
     };
 
-    const deleteHoliday = (date: Date) => {
-      store.dispatch("holidays/deleteHoliday", formatISO(new Date(date)));
+    const deleteHoliday = (ymd: string) => {
+      store.dispatch("holidays/deleteHoliday", ymd);
     };
 
-    const dateClass = (_: any, date: Date) => {
-      return holidays.value.some((holidayDate) => {
-        isSameDay(date, new Date(holidayDate));
-      });
+    const dateClass = (ymd: string) => {
+      const isHoliday = holidays.value.some(
+        (holidayDate) => ymd === holidayDate
+      );
+
+      return isHoliday ? "is-holiday" : "";
     };
 
     return {

--- a/plugins/filters.ts
+++ b/plugins/filters.ts
@@ -1,11 +1,13 @@
 import Vue from "vue";
 import { format } from "date-fns";
 
+import { getDayOnGMT } from "~/helpers/dates";
+
 Vue.filter("formatDate", (value: string, formatString: string) => {
   if (!value) return "";
 
   formatString = formatString || "";
-  const date = new Date(value);
+  const date = getDayOnGMT(value);
 
   return format(date, formatString);
 });

--- a/services/holidays-service.ts
+++ b/services/holidays-service.ts
@@ -1,7 +1,5 @@
 import { NuxtFireInstance } from "@nuxtjs/firebase";
-import { compareAsc, isSameDay } from "date-fns";
-
-import { formatDate } from "~/helpers/dates";
+import { compareAsc } from "date-fns";
 
 export default class HolidaysService {
   fire: NuxtFireInstance;
@@ -22,7 +20,7 @@ export default class HolidaysService {
 
   async saveHoliday(date: string) {
     const { docId, dates } = await this.getHolidays();
-    const newDates: string[] = [...dates, formatDate(date)];
+    const newDates: string[] = [...dates, date];
 
     const sortedDates = newDates.sort((accDate, currDate) =>
       compareAsc(new Date(accDate), new Date(currDate))
@@ -36,9 +34,7 @@ export default class HolidaysService {
 
   async deleteHoliday(date: string) {
     const { docId, dates } = await this.getHolidays();
-    const newDates = dates.filter(
-      (x) => !isSameDay(new Date(x), new Date(date))
-    );
+    const newDates = dates.filter((holidayDate) => date !== holidayDate);
 
     const ref = this.fire.firestore.collection("holidays").doc(docId);
     await ref.set({ dates: newDates });

--- a/store/records/actions.ts
+++ b/store/records/actions.ts
@@ -2,7 +2,7 @@
 import { addDays, startOfISOWeek, subDays, isWithinInterval } from "date-fns";
 import { ActionTree } from "vuex";
 
-import { buildWeek } from "~/helpers/dates";
+import { buildWeek, getDayOnGMT } from "~/helpers/dates";
 import {
   getTimeRecordsToSave,
   getTravelRecordsToSave,
@@ -49,9 +49,9 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
     let newStartDate = new Date();
 
     if (payload.to === "previous") {
-      newStartDate = subDays(new Date(currentStartDate), 7);
+      newStartDate = subDays(getDayOnGMT(currentStartDate), 7);
     } else if (payload.to === "next") {
-      newStartDate = addDays(new Date(currentStartDate), 7);
+      newStartDate = addDays(getDayOnGMT(currentStartDate), 7);
     }
 
     const selectedWeek = buildWeek(startOfISOWeek(newStartDate), []);

--- a/store/reports/actions.ts
+++ b/store/reports/actions.ts
@@ -1,20 +1,22 @@
 import { startOfMonth, lastDayOfMonth, startOfISOWeek } from "date-fns";
 import { ActionTree } from "vuex";
+
 import { checkEmployeeAvailability } from "../../helpers/employee";
 import { filterApprovedRecords } from "~/helpers/record-status";
+import { getDayOnGMT } from "~/helpers/dates";
 
 const actions: ActionTree<ReportsStoreState, RootStoreState> = {
   async getMonthlyReportData({ commit }, payload: { startDate: Date }) {
     commit("setIsLoading", { isLoading: true });
 
-    const startDate = startOfMonth(payload.startDate);
-    const endDate = lastDayOfMonth(payload.startDate);
+    const startDate = getDayOnGMT(startOfMonth(payload.startDate));
+    const endDate = getDayOnGMT(lastDayOfMonth(payload.startDate));
 
     const customersPromise = this.app.$customersService.getCustomers();
     const employeesPromise = this.app.$employeesService.getEmployees();
     const timesheetsPromise = this.app.$timesheetsService.getApprovedTimesheets(
       {
-        startDate: startOfISOWeek(startDate).getTime(),
+        startDate: getDayOnGMT(startOfISOWeek(startDate)).getTime(),
         endDate: endDate.getTime(),
       }
     );

--- a/store/timesheets/actions.ts
+++ b/store/timesheets/actions.ts
@@ -30,8 +30,10 @@ const actions: ActionTree<TimesheetsStoreState, RootStoreState> = {
 
     const employeesPromise = this.app.$employeesService.getEmployees();
     const timesheetsPromise = this.app.$timesheetsService.getTimesheets({
-      startDate: weeksSpan[0].start.date,
-      endDate: weeksSpan[payload.weeksBefore + payload.weeksAfter].start.date,
+      startDate: new Date(weeksSpan[0].start.ISO).getTime(),
+      endDate: new Date(
+        weeksSpan[payload.weeksBefore + payload.weeksAfter].start.ISO
+      ).getTime(),
     });
 
     const [employees, timesheets] = await Promise.all([


### PR DESCRIPTION
# Changes

## Related issues

Resolves #68 and #69 

## Added

- New date helper methods to handle timezones

## Removed

- Helper functions on dates and record-status files that weren’t being used anymore.

## Changed

- Now the application carefully converts dates to a standard GMT timezone on runtime to correctly compare dates without any conflict due to timezone differences.

## How to test

- Go through all functionalities and check if there is inconsistency on dates or on data fetched by dates.

## Screenshots

N/A
