### PR TITLE
Feat: add reason of denial message

### DIFF
--- a/components/timesheets/weekly-timesheet-admin-footer.vue
+++ b/components/timesheets/weekly-timesheet-admin-footer.vue
@@ -18,10 +18,10 @@
 
     <template v-if="!isClosed">
       <b-button
+        v-b-modal.deny-modal
         class="mr-3"
         variant="danger"
         :disabled="isSaving"
-        @click="handleDenyClick"
       >
         Deny
       </b-button>
@@ -86,7 +86,6 @@ export default defineComponent({
     let intervalHandle: NodeJS.Timeout;
 
     const handleSaveClick = () => emit("save");
-    const handleDenyClick = () => emit("deny");
     const handleApproveClick = () => emit("approve");
 
     const isApproved = computed(() => props.status === recordStatus.APPROVED);
@@ -114,7 +113,6 @@ export default defineComponent({
 
     return {
       handleSaveClick,
-      handleDenyClick,
       handleApproveClick,
       isClosed,
       isApproved,

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -20,6 +20,12 @@ export default (employeeId: string, startTimestamp?: number) => {
       : (recordStatus.NEW as TimesheetStatus)
   );
 
+  const timesheetDenyMessage = computed(() =>
+    timesheetState.value.timesheets[0]
+      ? timesheetState.value.timesheets[0].reasonOfDenial
+      : ""
+  );
+
   const isReadonly = computed(
     () =>
       timesheetStatus.value === recordStatus.APPROVED ||
@@ -111,19 +117,37 @@ export default (employeeId: string, startTimestamp?: number) => {
     { deep: true }
   );
 
-  const saveTimesheet = (newTimesheetStatus: TimesheetStatus) => {
+  const saveTimesheet = (
+    newTimesheetStatus: TimesheetStatus,
+    denialMessage?: string
+  ) => {
     store.dispatch("records/saveTimesheet", {
       employeeId,
       week: recordsState.value.selectedWeek,
       timesheet: timesheet.value,
     });
 
+    let reasonOfDenial = "";
+    if (timesheetState.value.timesheets[0]) {
+      reasonOfDenial = timesheetState.value.timesheets[0].reasonOfDenial;
+    }
+    if (newTimesheetStatus === recordStatus.DENIED && denialMessage) {
+      reasonOfDenial = denialMessage;
+    } else if (newTimesheetStatus === recordStatus.PENDING) {
+      reasonOfDenial = "";
+    }
+
     const newTimesheet = timesheetState.value.timesheets[0]
-      ? { ...timesheetState.value.timesheets[0], status: newTimesheetStatus }
+      ? {
+          ...timesheetState.value.timesheets[0],
+          status: newTimesheetStatus,
+          reasonOfDenial,
+        }
       : {
           employeeId,
           date: new Date(recordsState.value.selectedWeek[0].date).getTime(),
           status: newTimesheetStatus,
+          reasonOfDenial,
         };
 
     store.dispatch("timesheets/saveTimesheet", newTimesheet);
@@ -143,5 +167,6 @@ export default (employeeId: string, startTimestamp?: number) => {
     saveTimesheet,
     timesheetStatus,
     isReadonly,
+    timesheetDenyMessage,
   };
 };

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -103,7 +103,7 @@
       />
 
       <b-alert
-        :show="Boolean(timesheetDenyMessage)"
+        :show="timesheetDenyMessage !== ''"
         variant="danger"
         class="my-3"
       >

--- a/types/timesheets.d.ts
+++ b/types/timesheets.d.ts
@@ -28,6 +28,7 @@ interface Timesheet {
   date: number;
   employeeId: string;
   status: TimesheetStatus;
+  reasonOfDenial: string;
 }
 
 interface WeekSpan {


### PR DESCRIPTION
# Changes

## Related issues

Solves #25 

## Added

- Reason of denial field on timesheets
- Modal to add the reason of denial when denying a timesheet
- Show reason of denial message when seeing the denied record

## Removed

- The DENY emmit event

## Changed

N/A

## How to test

- Try to deny a timesheet
- A modal should show, asking you to add the reason for denial
- See if the message is shown when viewing the given timesheet
- Submit the timesheet again and check if the message disappears

## Screenshots

<img width="1552" alt="Screen Shot 2021-05-19 at 00 04 35" src="https://user-images.githubusercontent.com/45885054/118751102-1f228480-b837-11eb-9305-e8cafa797272.png">

