### PR TITLE
fix(employees): change to absolute path

### DIFF
--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -86,7 +86,7 @@ export default defineComponent({
     store.dispatch("employees/getEmployees");
 
     const openEmployeePage = (employee: Employee) => {
-      router.push(`employees/${employee.id}`);
+      router.push(`/employees/${employee.id}`);
     };
 
     const newEmployee = ref({


### PR DESCRIPTION
# Changes

## Related issues

Solves #81 

## Added

N/A

## Removed

N/A

## Changed

- Change link to employee page to use absolute path

## How to test

- Click on a link to an employee page and check if it works

## Screenshots

N/A
