### PR TITLE
Feature/mobile optimisations

### DIFF
--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -81,11 +81,14 @@ export default defineComponent({
     flex: 0 0 auto;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    max-width: 100%;
   }
 
   &__week-label {
     flex: 1 1 auto;
-    margin: 0 0 0 8px;
+    // margin: 0 0 0 8px;
     font-size: 18px;
     font-weight: bold;
 

--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="navigation-buttons">
     <div class="navigation-buttons__container">
-      <b-button-group>
+      <b-button-group class="navigation-buttons__date-group">
         <b-button @click="handlePreviousClick()">
           <b-icon icon="arrow-left" />
         </b-button>
@@ -10,7 +10,6 @@
           @click="handleCurrentClick()"
         >
           <b-icon icon="calendar2-date" />
-          <span class="ml-2 d-none d-sm-inline">This week</span>
         </b-button>
 
         <b-button :disabled="weekDifference > 3" @click="handleNextClick()">
@@ -83,16 +82,24 @@ export default defineComponent({
     align-items: center;
     flex-wrap: wrap;
     gap: 8px;
+    width: 100%;
     max-width: 100%;
+  }
+
+  &__date-group {
+    width: 100%;
+
+    @media (min-width: 560px) {
+      width: unset;
+    }
   }
 
   &__week-label {
     flex: 1 1 auto;
-    // margin: 0 0 0 8px;
     font-size: 18px;
     font-weight: bold;
 
-    @media (min-width: 576px) {
+    @media (min-width: 560px) {
       font-size: 24px;
     }
   }

--- a/components/records/weekly-timesheet-footer.vue
+++ b/components/records/weekly-timesheet-footer.vue
@@ -1,30 +1,27 @@
 <template>
   <div class="weekly-timesheet-footer">
-    <div>
-      <span v-if="lastSaved">Last saved: {{ lastSavedLabel }}</span>
-      <b-spinner v-if="isSaving" small />
-
-      <b-button
-        v-if="canSubmitForApproval"
-        class="ml-3"
-        :disabled="isSaving || !hasUnsavedChanges"
-        @click="handleSaveClick"
-      >
-        Update
-      </b-button>
-
-      <b-button
-        v-if="canUnsubmitForApproval"
-        class="ml-3"
-        :disabled="isSaving"
-        @click="handleUnsubmitClick"
-      >
-        Unsubmit
-      </b-button>
+    <div class="weekly-timesheet-footer__status">
+      <span v-if="lastSaved">Last saved: {{ lastSavedLabel }} ago</span>
+      <b-spinner v-if="isSaving" class="ml-1" small />
     </div>
 
     <b-button
-      class="ml-3"
+      v-if="canSubmitForApproval"
+      :disabled="isSaving || !hasUnsavedChanges"
+      @click="handleSaveClick"
+    >
+      Update
+    </b-button>
+
+    <b-button
+      v-if="canUnsubmitForApproval"
+      :disabled="isSaving"
+      @click="handleUnsubmitClick"
+    >
+      Unsubmit
+    </b-button>
+
+    <b-button
       :disabled="isSaving || !canSubmitForApproval"
       @click="handleSubmitClick"
     >
@@ -131,7 +128,18 @@ export default defineComponent({
 <style lang="scss" scoped>
 .weekly-timesheet-footer {
   display: flex;
-  align-items: center;
-  justify-content: flex-end;
+  gap: 16px;
+  flex-direction: column;
+
+  @media (min-width: 560px) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &__status {
+    display: inline-flex;
+    align-items: center;
+  }
 }
 </style>

--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -1,6 +1,6 @@
 <template>
   <b-row class="weekly-timesheet-row" cols="14">
-    <b-col cols="4">
+    <b-col class="weekly-timesheet-row__action-column" cols="4">
       <b-button
         v-if="canRemove"
         class="weekly-timesheet-row__remove-button"
@@ -125,6 +125,14 @@ export default defineComponent({
   color: var(--body-color);
   align-items: center;
 
+  + .weekly-timesheet-row {
+    padding-top: 12px;
+
+    @media (min-width: 560px) {
+      padding-top: 0;
+    }
+  }
+
   &__remove-button {
     display: inline-flex;
     align-items: center;
@@ -133,10 +141,24 @@ export default defineComponent({
     border: 0;
   }
 
+  &__action-column {
+    @media (max-width: 560px) {
+      flex: unset;
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+
   &__date-column {
-    padding: 8px;
+    flex: 1;
+    padding: 2px;
     text-align: center;
     background-color: #fff;
+    max-width: 100%;
+
+    @media (min-width: 768px) {
+      padding: 8px;
+    }
 
     &.holiday,
     &.weekend {
@@ -158,6 +180,11 @@ export default defineComponent({
 
   &__total-column {
     text-align: right;
+    padding: 0 4px;
+
+    @media (min-width: 560px) {
+      padding: 0 15px;
+    }
   }
 }
 </style>

--- a/components/records/weekly-timesheet-totals-row.vue
+++ b/components/records/weekly-timesheet-totals-row.vue
@@ -1,6 +1,6 @@
 <template>
   <b-row class="weekly-timesheet-totals-row" cols="14">
-    <b-col cols="4">
+    <b-col class="weekly-timesheet-totals-row__action" cols="4">
       <b-button
         v-if="showAddProjectButton"
         v-b-modal.modal-add-project
@@ -21,10 +21,7 @@
     </b-col>
 
     <!-- TODO: use classes and show {{ weekTotal / weekTheoraticalTotal }} when `workSchem` API is implemented -->
-    <b-col
-      cols="1"
-      class="weekly-timesheet-totals-row__week-column d-none d-sm-block"
-    >
+    <b-col cols="1" class="weekly-timesheet-totals-row__week-column d-sm-block">
       <span>
         <strong>{{ weekTotal }}</strong>
       </span>
@@ -104,9 +101,23 @@ export default defineComponent({
   padding-top: 8px;
   padding-bottom: 8px;
 
+  &__action {
+    @media (max-width: 560px) {
+      flex: 100%;
+      max-width: 100%;
+    }
+  }
+
   &__column {
+    flex: 1;
+    max-width: 100%;
     padding: 8px;
     text-align: center;
+
+    @media (max-width: 560px) {
+      flex: 1;
+      max-width: 100%;
+    }
 
     &.exceeded {
       color: red;
@@ -121,6 +132,11 @@ export default defineComponent({
   &__week-column {
     padding-right: 16px;
     text-align: right;
+    padding: 0 4px;
+
+    @media (min-width: 560px) {
+      padding: 0 15px;
+    }
 
     &.exceeded {
       color: red;

--- a/components/records/weekly-timesheet.vue
+++ b/components/records/weekly-timesheet.vue
@@ -3,7 +3,7 @@
     <b-container fluid>
       <b-row cols="14">
         <!-- TODO: could be auto? -->
-        <b-col cols="4" />
+        <b-col class="weekly-timesheet__action-column" cols="4" />
 
         <b-col
           v-for="date in selectedWeek"
@@ -12,7 +12,7 @@
           class="weekly-timesheet__date-column"
           :class="{ today: date.isToday }"
         >
-          <strong>
+          <strong class="d-block">
             <span class="d-md-none">{{ date.weekDayShort }}</span>
             <span class="d-none d-md-block">{{ date.weekDay }}</span>
           </strong>
@@ -53,23 +53,43 @@ export default defineComponent({
   border-left: 1px solid var(--color-primary);
   border-radius: 8px;
 
+  &__action-column {
+    display: none;
+
+    @media (min-width: 560px) {
+      display: block;
+    }
+  }
+
   &__date-column {
     text-align: center;
     padding: 8px;
     line-height: 1.2;
+
+    @media (max-width: 560px) {
+      flex: 1;
+      max-width: 100%;
+    }
 
     &.today::after {
       content: "TODAY";
       position: absolute;
       top: -17px;
       right: 0;
-      left: 0;
       height: 17px;
+      min-width: 3rem;
+      left: 50%;
+      transform: translateX(-50%);
       padding-top: 2px;
       font-size: 12px;
       background-color: var(--color-primary);
       color: var(--color-primary-text);
       border-radius: 4px 4px 0 0;
+
+      @media (min-width: 560px) {
+        left: 0;
+        transform: none;
+      }
     }
   }
 }

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -120,6 +120,6 @@ export function getDayOnGMT(initialZonedValue: Date | number | string) {
   const zonedDate = new Date(initialZonedValue);
   return new Date(
     zonedDate.getTime() +
-      zonedDate.getTimezoneOffset() * MILLISECONDS_IN_MINUTES
+    zonedDate.getTimezoneOffset() * MILLISECONDS_IN_MINUTES
   );
 }

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -30,7 +30,6 @@ export function getDateLabel(startDate: Date, endDate: Date) {
   const thisWeek = today <= endDate && today >= startDate;
 
   let label = format(startDate, "dd");
-  label = `${thisWeek ? "This Week: " : ""}${label}`;
   if (startDate.getMonth() !== endDate.getMonth()) {
     label += ` ${format(startDate, "MMM")}`;
 


### PR DESCRIPTION
# Changes

## Related issues

<!--- Add link to issue  -->

## Added

I added a mobile optimised layout for the weekly-timesheets.

## Removed

I removed several labels with @sanderdejong88 as they are redundant.

## Changed

Only layout changes have been made. Logic wise everything should work the same as before.

## How to test

Open the weekly-timesheets on a mobile browser. The below added visual changes should be visible.

## Screenshots

Before:
<img width="394" alt="Before" src="https://user-images.githubusercontent.com/14149640/120650028-aac62300-c47d-11eb-8275-f0b51bdf91e8.png">

After:
<img width="363" alt="After" src="https://user-images.githubusercontent.com/14149640/120650072-b6194e80-c47d-11eb-8ba5-2f97fb51c0e1.png">

## Note
- There seems to be no real variable usage in the CSS. Therefore, I followed how the rest of the code is written and hardcoded pixel values.
- max-widths are used to prevent having to put bootstrap styles back
