### PR TITLE
feat(records): use dot as float point separator

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -28,10 +28,8 @@
       <b-form-input
         v-model="project.values[index]"
         class="weekly-timesheet-row__value-input"
-        type="number"
+        type="text"
         :formatter="valueFormatter.formatter"
-        :min="valueFormatter.min"
-        :max="valueFormatter.max"
         :readonly="isReadonlyList[index]"
         @focus.native="handleInputFocus($event.target, index)"
         @input="$emit('change')"
@@ -82,8 +80,11 @@ export default defineComponent({
       emit("remove", props.project);
     };
 
-    const totalValue = computed(() =>
-      props.project.values.reduce((total, current) => total + current)
+    const totalValue = computed(
+      () =>
+        +props.project.values
+          .reduce((total, current) => total + +current)
+          .toFixed(1)
     );
 
     // An array of booleans, one for each day of the selected week, that states

--- a/components/records/weekly-timesheet-totals-row.vue
+++ b/components/records/weekly-timesheet-totals-row.vue
@@ -59,7 +59,9 @@ export default defineComponent({
       let total = 0;
 
       props.projects.forEach((project) => {
-        total += project.values.reduce((prevValue, value) => prevValue + value);
+        total += +project.values
+          .reduce((prevValue, value) => prevValue + +value)
+          .toFixed(1);
       });
 
       return total;

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -181,10 +181,21 @@ const findRecordByDate = (
 
 export function generateValueFormatter(min: number, max: number) {
   return {
-    min,
-    max,
-    formatter: (value: number) =>
-      Math.min(Math.max(Number(value) || 0, min), max),
+    formatter: (value: string, event: FocusEvent | InputEvent) => {
+      // Allows only numbers and a max of 1 dot
+      const formatted = value.replace(/[^0-9.]+|\.(?=.*\.)/g, "");
+
+      // Don’t convert to number when the string ends with a dot, so we can add
+      // float numbers. In this case a string will be returned.
+      if (formatted.match(/\.$/)) {
+        // On blur, return a number
+        if (event.type === "blur") return +formatted || 0;
+        return formatted;
+      }
+
+      // Validates range and returns a number
+      return +Math.min(Math.max(Number(formatted), min), max).toFixed(1);
+    },
   };
 }
 


### PR DESCRIPTION
# Changes

## Related issues

Solves #95 

## Notes

- The Application already has support to float numbers, but due to localization, devices using Chrome with a locale that uses comma as float point separator won't be able to use dot. This PR adds a workaround to use the dot as the standardized separator.
- More details on this problem here: https://medium.com/takeaway-tech/solving-cross-browsers-localization-on-numeric-inputs-3f7aec57aaeb

## Added

N/A

## Removed

N/A

## Changed

- Records inputs now are of type text
- Truncated values to one decimal place
- Shows NaN when invalid input is temporarily placed
- Changes to a securely converted value on input blur

## How to test

- Try to add float numbers as timerecords

## Screenshots

N/A
