### PR TITLE
fix(records): delete ids on copy timesheet

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -93,16 +93,31 @@ export default (employeeId: string, startTimestamp?: number) => {
   };
 
   const copyPreviousWeek = () => {
-    const startDate = new Date(recordsState.value.selectedWeek[0].date);
+    const startDate = new Date(
+      getDayOnGMT(recordsState.value.selectedWeek[0].date)
+    );
     const prevStartDate = subDays(startDate, 7);
     const previousWeek = buildWeek(startOfISOWeek(prevStartDate), []);
 
-    timesheet.value = createWeeklyTimesheet({
+    const previousWeekTimesheet = createWeeklyTimesheet({
       week: previousWeek,
       timeRecords: recordsState.value.timeRecords,
       travelRecords: recordsState.value.travelRecords,
       workScheme: recordsState.value.workScheme,
     });
+
+    const newTimesheet = {
+      projects: previousWeekTimesheet.projects.map((project) => ({
+        ...project,
+        ids: new Array(7).fill(null),
+      })),
+      travelProject: {
+        ...previousWeekTimesheet.travelProject!,
+        ids: new Array(7).fill(null),
+      },
+    };
+
+    timesheet.value = newTimesheet;
 
     hasUnsavedChanges.value = true;
   };


### PR DESCRIPTION
# Changes

## Related issues

Resolves #94 

## Added

N/A

## Removed

N/A

## Changed

- Clear ids arrays for projects and travel projects when copying the previous week records
- Correctly get the previous week's date even on different time zones.

## How to test

- Create a timesheet and save it
- Go to the next week and copy the previous records
- Deleting or updating the new records shouldn’t affect the previous records

## Screenshots

N/A
