### PR TITLE
Fix: holidays not working

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -163,7 +163,7 @@ export default defineComponent({
 
     &.holiday,
     &.weekend {
-      background-color: #e4e4e4;
+      background-color: #999;
     }
   }
 

--- a/components/records/weekly-timesheet.vue
+++ b/components/records/weekly-timesheet.vue
@@ -10,7 +10,7 @@
           :key="date.weekDay"
           cols="1"
           class="weekly-timesheet__date-column"
-          :class="{ today: date.isToday }"
+          :class="{ today: date.isToday, holiday: date.isHoliday }"
         >
           <strong class="d-block">
             <span class="d-md-none">{{ date.weekDayShort }}</span>
@@ -71,8 +71,8 @@ export default defineComponent({
       max-width: 100%;
     }
 
-    &.today::after {
-      content: "TODAY";
+    &.today::after,
+    &.holiday::after {
       position: absolute;
       top: -17px;
       right: 0;
@@ -90,6 +90,18 @@ export default defineComponent({
         left: 0;
         transform: none;
       }
+    }
+
+    &.today::after {
+      content: "TODAY";
+    }
+
+    &.holiday::after {
+      content: "HOLIDAY";
+    }
+
+    &.today.holiday::after {
+      content: "TDY/HOLI";
     }
   }
 }

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -58,6 +58,20 @@ export default (employeeId: string, startTimestamp?: number) => {
     { immediate: true }
   );
 
+  const hasRestDayHours = computed(() => {
+    return timesheet.value.projects.reduce((_, project) => {
+      return project.values.reduce((acc, value, index) => {
+        if (!value) return acc;
+
+        return (
+          index === 5 ||
+          index === 6 ||
+          recordsState.value.selectedWeek[index].isHoliday
+        );
+      }, false);
+    }, false);
+  });
+
   const goToWeek = (to: "current" | "previous" | "next") => {
     if (hasUnsavedChanges.value) {
       const confirmation = confirm(
@@ -150,6 +164,14 @@ export default (employeeId: string, startTimestamp?: number) => {
     newTimesheetStatus: TimesheetStatus,
     denialMessage?: string
   ) => {
+    if (newTimesheetStatus === recordStatus.NEW && hasRestDayHours.value) {
+      const confirmation = confirm(
+        "You have add hours on weekends or holidays, are you sure you want to save this timesheet?"
+      );
+
+      if (!confirmation) return;
+    }
+
     store.dispatch("records/saveTimesheet", {
       employeeId,
       week: recordsState.value.selectedWeek,

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -1,11 +1,4 @@
-import {
-  format,
-  isToday,
-  isWeekend,
-  isSameDay,
-  startOfISOWeek,
-  addWeeks,
-} from "date-fns";
+import { format, isToday, isWeekend, startOfISOWeek, addWeeks } from "date-fns";
 
 export function formatDate(dirtyDate: string | number | Date) {
   const date = new Date(dirtyDate);
@@ -26,9 +19,6 @@ export function addDays(dirtyDate: string | number | Date, days: number) {
 
 // based on a date, create a label with the begin and enddate of that week
 export function getDateLabel(startDate: Date, endDate: Date) {
-  const today = new Date();
-  const thisWeek = today <= endDate && today >= startDate;
-
   let label = format(startDate, "dd");
   if (startDate.getMonth() !== endDate.getMonth()) {
     label += ` ${format(startDate, "MMM")}`;
@@ -59,7 +49,7 @@ export function buildWeek(
       year: format(newDate, "yyyy"),
       isWeekend: isWeekend(newDate),
       isToday: isToday(newDate),
-      isHoliday: holidays.some((date) => isSameDay(new Date(date), newDate)),
+      isHoliday: holidays.some((date) => date === formatDate(newDate)),
     };
   });
 }
@@ -119,6 +109,6 @@ export function getDayOnGMT(initialZonedValue: Date | number | string) {
   const zonedDate = new Date(initialZonedValue);
   return new Date(
     zonedDate.getTime() +
-    zonedDate.getTimezoneOffset() * MILLISECONDS_IN_MINUTES
+      zonedDate.getTimezoneOffset() * MILLISECONDS_IN_MINUTES
   );
 }

--- a/store/records/actions.ts
+++ b/store/records/actions.ts
@@ -10,12 +10,14 @@ import {
 
 const actions: ActionTree<RecordsStoreState, RootStoreState> = {
   async getRecords(
-    { commit },
+    { commit, rootState },
     payload: { employeeId: string; startDate: Date }
   ) {
     commit("setLoading", { isLoading: true });
 
-    const selectedWeek = buildWeek(startOfISOWeek(payload.startDate), []);
+    const holidays = rootState.holidays.holidays;
+
+    const selectedWeek = buildWeek(startOfISOWeek(payload.startDate), holidays);
     const workSchemeResult = await this.app.$workSchemeService.getWorkScheme({
       employeeId: payload.employeeId,
       startDate: new Date(selectedWeek[0].date),
@@ -42,7 +44,7 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
   },
 
   async goToWeek(
-    { commit, state },
+    { commit, state, rootState },
     payload: { employeeId: string; to: "current" | "next" | "previous" }
   ) {
     const currentStartDate = state.selectedWeek[0].date;
@@ -54,7 +56,9 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
       newStartDate = addDays(getDayOnGMT(currentStartDate), 7);
     }
 
-    const selectedWeek = buildWeek(startOfISOWeek(newStartDate), []);
+    const holidays = rootState.holidays.holidays;
+
+    const selectedWeek = buildWeek(startOfISOWeek(newStartDate), holidays);
     const workSchemeResult = await this.app.$workSchemeService.getWorkScheme({
       employeeId: payload.employeeId,
       startDate: new Date(selectedWeek[0].date),


### PR DESCRIPTION
# Changes

## Related issues

Solves #100 

## Added

- Request confirmation before saving hours of weekends or holidays
- Add a column mark for holidays

## Removed

N/A

## Changed

- Pass holidays to the `buildWeek` function calls
- Check if is a holiday comparing strings (ISO formatted) and not dates
- Darker background for holidays and weekends 

## How to test

- Check if holidays and weekends get the dark gray background 
- Add hours to a holiday or weekend and try to save
- A confirmation pop-up should appear asking if you want to save it anyway 

## Screenshots

N/A
