### PR TITLE
fix(timesheets): remove timezone conversion of start date

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -39,7 +39,7 @@ export default (employeeId: string, startTimestamp?: number) => {
     travelProject: null,
   });
 
-  const initialDate = startTimestamp ? getDayOnGMT(startTimestamp) : new Date();
+  const initialDate = startTimestamp ? new Date(startTimestamp) : new Date();
 
   store.dispatch("records/getRecords", {
     employeeId,


### PR DESCRIPTION
# Changes

## Related issues

Solves #96 

## Added

N/A

## Removed

N/A

## Changed

- Remove the unnecessary timezone conversion and just used the local date instead. Now the records page can fetch the correct timesheet.

## How to test

- Go to the timesheets page
- Click on one of the tiles buttons
- Check if it navigates to the right week

## Screenshots

N/A
