### PR TITLE
feat(timesheets): add back to timesheets button

### DIFF
--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -1,6 +1,19 @@
 <template>
   <div class="navigation-buttons">
     <div class="navigation-buttons__container">
+      <nuxt-link
+        v-if="isAdminView"
+        to="/timesheets"
+        class="d-flex align-items-center flex-nowrap"
+      >
+        <b-button>
+          <b-icon class="mr-1" icon="chevron-left" aria-hidden="true" />
+          Timesheets
+        </b-button>
+      </nuxt-link>
+      <h2 class="navigation-buttons__week-label">
+        {{ weekLabel }}
+      </h2>
       <b-button-group class="navigation-buttons__date-group">
         <b-button @click="handlePreviousClick()">
           <b-icon icon="arrow-left" />
@@ -16,9 +29,6 @@
           <b-icon icon="arrow-right" />
         </b-button>
       </b-button-group>
-      <h2 class="navigation-buttons__week-label">
-        {{ weekLabel }}
-      </h2>
     </div>
   </div>
 </template>
@@ -35,6 +45,10 @@ export default defineComponent({
     selectedWeek: {
       type: Array as PropType<WeekDate[]>,
       default: () => [],
+    },
+    isAdminView: {
+      type: Boolean,
+      default: false,
     },
   },
   setup(props, { emit }) {
@@ -95,12 +109,14 @@ export default defineComponent({
   }
 
   &__week-label {
-    flex: 1 1 auto;
     font-size: 18px;
     font-weight: bold;
 
+    margin: 0 auto;
+
     @media (min-width: 560px) {
       font-size: 24px;
+      margin-right: 0;
     }
   }
 }

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -9,6 +9,7 @@
     <navigation-buttons
       class="mb-5"
       :selected-week="recordsState.selectedWeek"
+      :is-admin-view="isAdminView"
       @previous="goToWeek('previous')"
       @next="goToWeek('next')"
       @current="goToWeek('current')"


### PR DESCRIPTION
# Changes

## Related issues

Resolves #98 

## Added

- Back button on the admin view of the records page to go to the timesheets page

## Removed

N/A

## Changed

N/A

## How to test

- Go to a timesheet approval page
- Click on the "< Timesheets" button
- Check if it goes back to the timesheets page

## Screenshots

<img width="1552" alt="Screen Shot 2021-06-10 at 09 03 39" src="https://user-images.githubusercontent.com/45885054/121522693-bfe60900-c9cb-11eb-8152-9b258ba80bb2.png">

