### PR TITLE
Feature/admin toggler

### DIFF
--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -16,3 +16,14 @@ export const queryOnString = (target: string, query: string) =>
   normalizeText(target)
     .toUpperCase()
     .includes(normalizeText(query).toUpperCase());
+
+export function debounce(func: any, timeout = 300) {
+  let timer: any;
+  return (...args: any[]) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      // @ts-ignore
+      func.apply(this, args);
+    }, timeout);
+  };
+};

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -91,7 +91,7 @@
           </div>
 
           <div class="ml-auto d-flex">
-            <b-form-checkbox v-if="adminCheck" v-model="adminCheck[employee.email]" switch class="mt-2 mr-3">
+            <b-form-checkbox v-if="adminCheck" v-model="adminCheck[employee.email]" switch class="mt-2 mr-3" @change="(checked) => adminChange(checked, employee.email)">
               Admin
             </b-form-checkbox>
 
@@ -249,6 +249,18 @@ export default defineComponent({
       return check;
     });
 
+    const adminChange = (checked: any, email: string) => {
+      let adminList = [...store.getters["employees/adminList"]];
+
+      if (checked) {
+        adminList.push(email)
+      } else {
+        adminList = adminList.filter(admin => admin !== email);
+      }
+
+      store.dispatch("employees/updateAdminList", adminList);
+    }
+
     const newEmployee = ref({
       name: "",
       email: "",
@@ -276,6 +288,7 @@ export default defineComponent({
 
     return {
       adminCheck,
+      adminChange,
       employees,
       newEmployee,
       canAddEmployee,

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -5,7 +5,9 @@
         <b-row :no-gutters="true" class="px-3">
           <b-col>
             <div class="d-flex justify-content-end">
-              <b-button v-b-modal.modal-center> + New employee </b-button>
+              <b-button v-b-modal.modal-center>
+                + New employee
+              </b-button>
             </div>
           </b-col>
         </b-row>
@@ -21,7 +23,7 @@
               id="employee-search"
               v-model="searchInput"
               type="search"
-              placeholder='Ex.: "John"'
+              placeholder="Ex.: &quot;John&quot;"
             />
           </b-col>
 
@@ -88,12 +90,18 @@
             {{ employee.name }}
           </div>
 
-          <nuxt-link
-            class="btn btn-info ml-auto"
-            :to="`/employees/${employee.id}`"
-          >
-            Manage employee
-          </nuxt-link>
+          <div class="ml-auto d-flex">
+            <b-form-checkbox v-if="adminCheck" v-model="adminCheck[employee.email]" switch class="mt-2 mr-3">
+              Admin
+            </b-form-checkbox>
+
+            <nuxt-link
+              class="btn btn-info"
+              :to="`/employees/${employee.id}`"
+            >
+              Manage employee
+            </nuxt-link>
+          </div>
         </b-row>
       </b-container>
     </div>
@@ -162,6 +170,10 @@ export default defineComponent({
       if (customers.value.length === 0) {
         store.dispatch("customers/getCustomers");
       }
+
+      if (store.getters["employees/adminList"].length === 0) {
+        store.dispatch("employees/getAdminList");
+      }
     });
 
     const customerOptions = computed(() =>
@@ -227,6 +239,16 @@ export default defineComponent({
       );
     });
 
+    const adminCheck = computed((): {[key:string]: boolean} => {
+      const check: {[key:string]: boolean} = {};
+
+      store.getters["employees/adminList"].forEach((admin: string) => {
+        check[admin] = true;
+      });
+
+      return check;
+    });
+
     const newEmployee = ref({
       name: "",
       email: "",
@@ -253,6 +275,7 @@ export default defineComponent({
     };
 
     return {
+      adminCheck,
       employees,
       newEmployee,
       canAddEmployee,

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -91,10 +91,6 @@
           </div>
 
           <div class="ml-auto d-flex">
-            <b-form-checkbox v-if="adminCheck" v-model="adminCheck[employee.email]" switch class="mt-2 mr-3" @change="(checked) => debouncedAdminChange(checked, employee.email)">
-              Admin
-            </b-form-checkbox>
-
             <nuxt-link
               class="btn btn-info"
               :to="`/employees/${employee.id}`"
@@ -146,7 +142,7 @@ import Multiselect from "vue-multiselect";
 import { validateEmail } from "../../helpers/validation";
 import { formatDate } from "~/helpers/dates";
 import { checkEmployeeAvailability } from "~/helpers/employee";
-import { queryOnString, debounce } from "~/helpers/helpers";
+import { queryOnString } from "~/helpers/helpers";
 
 export default defineComponent({
   components: { Multiselect },
@@ -169,10 +165,6 @@ export default defineComponent({
 
       if (customers.value.length === 0) {
         store.dispatch("customers/getCustomers");
-      }
-
-      if (store.getters["employees/adminList"].length === 0) {
-        store.dispatch("employees/getAdminList");
       }
     });
 
@@ -239,38 +231,6 @@ export default defineComponent({
       );
     });
 
-    const adminCheck = computed((): {[key:string]: boolean} => {
-      const check: {[key:string]: boolean} = {};
-
-      store.getters["employees/adminList"].forEach((admin: string) => {
-        check[admin] = true;
-      });
-
-      return check;
-    });
-
-    const debouncedAdminChange = debounce((checked: any, email: string) => {
-      return adminChange(checked, email);
-    });
-
-    const adminChange = (checked: any, email: string) => {
-      let valueChanged = false;
-      let adminList = [...store.getters["employees/adminList"]];
-      const alreadyContained = adminList.includes(email);
-
-      if (checked && !alreadyContained) {
-        adminList.push(email);
-        valueChanged = true;
-      }
-      if (!checked && alreadyContained) {
-        adminList = adminList.filter(admin => admin !== email);
-        valueChanged = true;
-      }
-
-      // Only dispatch if value changed. Failsafe for spamming the checkbox.
-      if (valueChanged) store.dispatch("employees/updateAdminList", adminList);
-    }
-
     const newEmployee = ref({
       name: "",
       email: "",
@@ -297,8 +257,6 @@ export default defineComponent({
     };
 
     return {
-      adminCheck,
-      debouncedAdminChange,
       employees,
       newEmployee,
       canAddEmployee,

--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -110,7 +110,7 @@ export default class EmployeesService {
     return adminEmails.includes(email);
   }
 
-  private async getAdminEmails(): Promise<string[]> {
+  public async getAdminEmails(): Promise<string[]> {
     const ref = this.fire.firestore.collection("admins");
     const snapshot = await ref.get();
     const result = snapshot.docs[0].data().admins || [];

--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -117,4 +117,13 @@ export default class EmployeesService {
 
     return (result as unknown) as string[];
   }
+
+  public async updateAdminEmails(adminList: string[]): Promise<string[]> {
+    const docs = await this.fire.firestore.collection("admins").get();
+    const docId = await docs.docs[0].id;
+    const ref = await this.fire.firestore.collection("admins").doc(docId);
+
+    await ref.update({ admins: adminList });
+    return adminList;
+  }
 }

--- a/store/employees/actions.ts
+++ b/store/employees/actions.ts
@@ -38,10 +38,16 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   },
 
   async getAdminList({commit, getters }) {
-    if (getters["employees/adminList"].length) return; // TODO Vlad maybe move to service?
+    if (getters["employees/adminList"]?.length) return; // TODO Vlad maybe move to service?
 
     const employeesService = new EmployeesService(this.$fire);
     const adminList = await employeesService.getAdminEmails();
+    commit("setAdminList", adminList);
+  },
+
+  async updateAdminList({commit}, payload: string[]) {
+    const employeesService = new EmployeesService(this.$fire);
+    const adminList = await employeesService.updateAdminEmails(payload);
     commit("setAdminList", adminList);
   },
 };

--- a/store/employees/actions.ts
+++ b/store/employees/actions.ts
@@ -1,4 +1,5 @@
 import { ActionTree } from "vuex";
+import EmployeesService from "~/services/employees-service";
 
 const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   async getEmployees({ commit }) {
@@ -34,6 +35,14 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   async updateEmployee({ commit }, payload: Employee) {
     await this.app.$employeesService.updateEmployee(payload);
     commit("updateEmployee", { employee: payload });
+  },
+
+  async getAdminList({commit, getters }) {
+    if (getters["employees/adminList"].length) return; // TODO Vlad maybe move to service?
+
+    const employeesService = new EmployeesService(this.$fire);
+    const adminList = await employeesService.getAdminEmails();
+    commit("setAdminList", adminList);
   },
 };
 

--- a/store/employees/actions.ts
+++ b/store/employees/actions.ts
@@ -1,5 +1,4 @@
 import { ActionTree } from "vuex";
-import EmployeesService from "~/services/employees-service";
 
 const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   async getEmployees({ commit }) {
@@ -40,14 +39,12 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   async getAdminList({commit, getters }) {
     if (getters["employees/adminList"]?.length) return; // TODO Vlad maybe move to service?
 
-    const employeesService = new EmployeesService(this.$fire);
-    const adminList = await employeesService.getAdminEmails();
+    const adminList = await this.app.$employeesService.getAdminEmails();
     commit("setAdminList", adminList);
   },
 
   async updateAdminList({commit}, payload: string[]) {
-    const employeesService = new EmployeesService(this.$fire);
-    const adminList = await employeesService.updateAdminEmails(payload);
+    const adminList = await this.app.$employeesService.updateAdminEmails(payload);
     commit("setAdminList", adminList);
   },
 };

--- a/store/employees/getters.ts
+++ b/store/employees/getters.ts
@@ -1,0 +1,10 @@
+
+import { GetterTree } from "vuex";
+
+const getters: GetterTree<EmployeesStoreState, RootStoreState> = {
+  adminList(state): string[] {
+    return state.adminList;
+  },
+};
+
+export default getters;

--- a/store/employees/mutations.ts
+++ b/store/employees/mutations.ts
@@ -1,6 +1,10 @@
 import { MutationTree } from "vuex";
 
 const mutations: MutationTree<EmployeesStoreState> = {
+  setAdminList: (state, payload: string[]) => {
+    state.adminList = payload;
+  },
+
   setEmployees: (state, payload: { employees: Employee[] }) => {
     state.employees = payload.employees;
   },

--- a/store/employees/state.ts
+++ b/store/employees/state.ts
@@ -1,3 +1,4 @@
 export default (): EmployeesStoreState => ({
+  adminList: [],
   employees: [],
 });

--- a/types/employees.d.ts
+++ b/types/employees.d.ts
@@ -1,3 +1,4 @@
 interface EmployeesStoreState {
+  adminList: string[];
   employees: Employee[];
 }


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/127

## Added

Added a toggler to set employee as admin from Employee list view 

## How to test

With an admin user, go to employees list. 
Note a toggler saying "Admin"
Clicking it will trigger an update in firestore in "admins" collection
Changes are debounced, so spamming the button will not spam-update. 

## Screenshots

![image](https://user-images.githubusercontent.com/85111889/124474754-3266c080-dda1-11eb-98e5-c469e5a6bd73.png)
