### PR TITLE
Feature/filter customers

### DIFF
--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -132,9 +132,10 @@ export default defineComponent({
       if (!searchTerm.value) return customers.value;
 
       const criteria: "name"|"debtor" = selectedCriteria.value;
+      const term = searchTerm.value?.toLowerCase();
 
       const filtered: Customer[] = customers.value?.filter((customer: Customer) => {
-          return customer[criteria]?.toLowerCase().includes(searchTerm.value?.toLowerCase()) && customer;
+          return customer[criteria]?.toLowerCase().includes(term);
         });
 
       return filtered;

--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -108,6 +108,7 @@ import {
   ref,
   useStore,
 } from "@nuxtjs/composition-api";
+import { queryOnString } from "~/helpers/helpers";
 
 export default defineComponent({
   middleware: ["isAdmin"],
@@ -132,10 +133,10 @@ export default defineComponent({
       if (!searchTerm.value) return customers.value;
 
       const criteria: "name"|"debtor" = selectedCriteria.value;
-      const term = searchTerm.value?.toLowerCase();
 
       const filtered: Customer[] = customers.value?.filter((customer: Customer) => {
-          return customer[criteria]?.toLowerCase().includes(term);
+          if (!searchTerm.value || !customer[criteria]) return customer;
+          return queryOnString(customer[criteria], searchTerm.value);
         });
 
       return filtered;

--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -3,9 +3,32 @@
     <div class="content-wrapper mt-5">
       <b-container class="mx-0 px-0 mb-3" fluid>
         <b-row :no-gutters="true">
-          <b-col>
+          <b-col cols="3">
+            <label class="employee-status__label" for="status-select">
+              Search by:
+            </label>
+            <b-form-select
+              id="status-select"
+              v-model="selectedCriteria"
+              :options="searchCriteria"
+            />
+          </b-col>
+          <b-col cols="4" class="pl-0">
+            <label class="employee-status__label" for="employee-search">
+              Search:
+            </label>
+            <b-input
+              id="employee-search"
+              v-model="searchTerm"
+              type="search"
+              placeholder="Ex.: &quot;Frontmen&quot;"
+            />
+          </b-col>
+          <b-col class="ml-auto mt-auto">
             <div class="d-flex justify-content-end">
-              <b-button v-b-modal.modal-center> + New customer </b-button>
+              <b-button v-b-modal.modal-center>
+                + New customer
+              </b-button>
             </div>
           </b-col>
         </b-row>
@@ -16,15 +39,27 @@
             <span class="font-weight-bold">Customers</span>
           </b-col>
         </b-row>
+
         <b-row
-          v-for="customer in customers"
+          v-if="!filteredCustomers.length"
+          class="app-table__row employee-row p-3 mr-0 align-items-center justify-content-center"
+        >
+          <b-icon-person-x class="mr-2" />
+          No customers found.
+        </b-row>
+
+        <b-row
+          v-for="customer in filteredCustomers"
+          v-else
           :key="customer.id"
           class="app-table__row py-3"
         >
           <b-col>
             <div class="font-weight-bold">
               {{ customer.name }}
-              <b-badge v-if="customer.isDefault"> Default </b-badge>
+              <b-badge v-if="customer.isDefault">
+                Default
+              </b-badge>
             </div>
             <div>
               {{ customer.debtor }}
@@ -86,6 +121,25 @@ export default defineComponent({
     const customers = computed(() => store.state.customers.customers);
     store.dispatch("customers/getCustomers");
 
+    const searchTerm = ref<string>("");
+    const searchCriteria: { value: "name"|"debtor"; text: string; }[] = [
+      { value: "name", text: "Customer name" },
+      { value: "debtor", text: "Debtor name" },
+    ];
+    const selectedCriteria = ref<"name"|"debtor">(searchCriteria[0].value);
+
+    const filteredCustomers = computed(() => {
+      if (!searchTerm.value) return customers.value;
+
+      const criteria: "name"|"debtor" = selectedCriteria.value;
+
+      const filtered: Customer[] = customers.value?.filter((customer: Customer) => {
+          return customer[criteria]?.toLowerCase().includes(searchTerm.value?.toLowerCase()) && customer;
+        });
+
+      return filtered;
+    });
+
     const newCustomer = ref({
       name: "",
       debtor: "",
@@ -108,7 +162,10 @@ export default defineComponent({
     };
 
     return {
-      customers,
+      filteredCustomers,
+      searchTerm,
+      searchCriteria,
+      selectedCriteria,
       newCustomer,
       canAddCustomer,
       addCustomer,


### PR DESCRIPTION
# Changes

Customers list can be filtered by name or by debtor

## Related issues
https://github.com/FrontMen/fm-hours/issues/123

## Changed

customers/index.vue
List can be filtered with the provided search term, based on selected criteria (customer name, and debtor name). 
The page now contains a select dropdown and an input field to perform said search, and a row for no results in the table.

## How to test
As an admin, go to the customers page. 
Initially, the entire list loads up.
Add search terms and the list is filtered out.
Change the "search by" criteria and see the results changing.
Remove the search term and the entire list is shown.

## Screenshots

![image](https://user-images.githubusercontent.com/85111889/124619461-f868ed80-de78-11eb-8ebf-96a7e83ecb08.png) 
![image](https://user-images.githubusercontent.com/85111889/124619515-028aec00-de79-11eb-98e0-b6de1963ba28.png)
![image](https://user-images.githubusercontent.com/85111889/124619555-0a4a9080-de79-11eb-9a9c-4f3568cc4e56.png)
![image](https://user-images.githubusercontent.com/85111889/124619600-11719e80-de79-11eb-923d-13b8f3f2312d.png)

