### PR TITLE
fix(auth): add full url and clear cookie

### DIFF
--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -25,6 +25,10 @@ export default class AuthService {
     return Cookies.get("hosted-tools-api-auth-2");
   }
 
+  deleteAuthCookie() {
+    return Cookies.remove("hosted-tools-api-auth-2");
+  }
+
   decodeAuthResponseToken(token: string): JWTResponse {
     return jwtDecode(token);
   }
@@ -41,7 +45,8 @@ export default class AuthService {
 
   getToken(ppid: string): Promise<GetTokenResponse> {
     return this.axios.$post(
-      "/api/get-token/hours.frontmen.nl/bridge.hosted-tools.com/" + ppid
+      "https://auth.hosted-tools.com/api/get-token/hours.frontmen.nl/bridge.hosted-tools.com/" +
+        ppid
     );
   }
 

--- a/store/employee/actions.ts
+++ b/store/employee/actions.ts
@@ -25,6 +25,7 @@ const actions: ActionTree<EmployeeStoreState, RootStoreState> = {
 
   logout({ commit }) {
     localStorage.removeItem("@fm-hours/ppid");
+    this.app.$authService.deleteAuthCookie();
 
     this.$fire.auth.signOut();
     this.app.router?.push("/");


### PR DESCRIPTION
# Changes

## Related issues

N/A

## Added

- remove auth cookie on logout 

## Removed

N/A

## Changed

- Pass full URL of auth API call

## How to test

- Check if possible to login on `prod` environment 

## Screenshots

N/A
