### PR TITLE
fix(auth): use new instace of authService on logout

### DIFF
--- a/store/employee/actions.ts
+++ b/store/employee/actions.ts
@@ -24,8 +24,10 @@ const actions: ActionTree<EmployeeStoreState, RootStoreState> = {
   },
 
   logout({ commit }) {
+    const authService = new AuthService(this.$fire, this.$axios);
+
     localStorage.removeItem("@fm-hours/ppid");
-    this.app.$authService.deleteAuthCookie();
+    authService.deleteAuthCookie();
 
     this.$fire.auth.signOut();
     this.app.router?.push("/");


### PR DESCRIPTION
# Changes

## Related issues

N/A

## Added

N/A

## Removed

N/A

## Changed

- Use a new instance of `authService` instead of the global one. The previous state was causing an error because the `logout` method was being invoked inside the `onAuthStateChanged` method that is triggered before the plugins injection

## How to test

- Get logged out by an expired ppid (or a mocked invalid ppid)
- Check if the app logs out without any unexpected exception

## Screenshots

N/A
