### PR TITLE
Add banner to send employee to intracto bridge app to manage leave

### DIFF
--- a/pages/records.vue
+++ b/pages/records.vue
@@ -3,7 +3,7 @@
     <b-alert show variant="info" class="mb-3">
       To request leave, please visit
       <strong>
-        <a href="https://bridge.hosted-tools.com/myprofile/absences" target="_blank">bridge!</a>
+        <a href="https://bridge.hosted-tools.com/myprofile/absences" target="_blank" rel="noreferrer">bridge!</a>
       </strong>
     </b-alert>
     <employee-header

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -1,5 +1,11 @@
 <template>
   <div class="content-wrapper mt-5">
+    <b-alert show variant="info" class="mb-3">
+      To request leave, please visit
+      <strong>
+        <a href="https://bridge.hosted-tools.com/myprofile/absences" target="_blank">bridge!</a>
+      </strong>
+    </b-alert>
     <employee-header
       v-if="isAdminView && employee"
       class="mb-5"
@@ -51,7 +57,9 @@
       <template
         v-if="employee && employee.travelAllowance && timesheet.travelProject"
       >
-        <h3 class="mt-5 mb-3">Travel allowance</h3>
+        <h3 class="mt-5 mb-3">
+          Travel allowance
+        </h3>
 
         <weekly-timesheet :selected-week="recordsState.selectedWeek">
           <template #rows>


### PR DESCRIPTION
# Changes
Banner on /record prompts employee to navigate to Bridge to request or manage leave/absence. 
## Related issues
https://github.com/FrontMen/fm-hours/issues/89

## Changed
Banner added on records.vue

## How to test
Navigate to app as employee, or navigate to /records as admin. 
Note  banner with link to bridge. 
Link opens a new tab towards bridge absences
If logged out of bridge, bridge login flow and redirect to absences handled by bridge.

## Screenshots

![image](https://user-images.githubusercontent.com/85111889/124736565-6e239680-df17-11eb-8f73-580e1decbdc4.png)
![image](https://user-images.githubusercontent.com/85111889/124736630-7e3b7600-df17-11eb-867c-e4429e32d2e7.png)

