### PR TITLE
fix: get correct time records for a given month

### DIFF
--- a/services/time-records-service.ts
+++ b/services/time-records-service.ts
@@ -38,7 +38,7 @@ export default class RecordsService {
     const snapshot = await this.fire.firestore
       .collection("time_records")
       .where("date", ">=", params.startDate.getTime())
-      .where("date", "<=", params.endDate.getTime())
+      .where("date", "<", params.endDate.getTime())
       .orderBy("date", "asc")
       .get();
 

--- a/store/reports/actions.ts
+++ b/store/reports/actions.ts
@@ -1,4 +1,4 @@
-import { startOfMonth, lastDayOfMonth, startOfISOWeek } from "date-fns";
+import { startOfMonth, addMonths, startOfISOWeek } from "date-fns";
 import { ActionTree } from "vuex";
 
 import { checkEmployeeAvailability } from "../../helpers/employee";
@@ -9,8 +9,9 @@ const actions: ActionTree<ReportsStoreState, RootStoreState> = {
   async getMonthlyReportData({ commit }, payload: { startDate: Date }) {
     commit("setIsLoading", { isLoading: true });
 
-    const startDate = getDayOnGMT(startOfMonth(payload.startDate));
-    const endDate = getDayOnGMT(lastDayOfMonth(payload.startDate));
+    const startDate = startOfMonth(payload.startDate);
+    const endDate = startOfMonth(addMonths(payload.startDate, 1));
+ 
 
     const customersPromise = this.app.$customersService.getCustomers();
     const employeesPromise = this.app.$employeesService.getEmployees();


### PR DESCRIPTION
# Changes

## Related issues
June has 22 working days; i.e. 176 hours for fulltime ppl.
Ppl (for example Anthony or Ye Jun) have submitted their timesheets and filled in every day; a total of 176 hours for June.
On the report page only 168 hours are showing up in the totals - it seems that there's a day missing.
<!--- Add link to issue  -->

## Added

<!--- What is new on this code? -->

## Removed
Removed getDayOnGMT from the variable startDate and endDate. Was giving incorrect date in local time (e.g 29th June instead of 30th June)
<!--- What was removed? -->

## Changed
Initially the fire store query looked for time records between the first day of the month and the last day of the month. Problem is that the last day of the month wouldn't taken into account the whole day itself (e.g. time 00:00 on 30 June). So the query wouldn't get the record for the 30th. Now the query looks for records between 1 June 00:00 and 1 July 00:00.

<!--- What has been changed? -->

## How to test
Please test this out.

1. Submit hours for a whole month
2. Approve those hours for the month
3. Check on Reports page that the hours are correct

<!--- Add some steps or scenarios of how to test and validate these changes -->

## Screenshots

<!--- In case of any visual changes, add some screenshots here -->
