### PR TITLE
Add sorting to customer list

### DIFF
--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -27,3 +27,11 @@ export function debounce(func: any, timeout = 300) {
     }, timeout);
   };
 };
+
+export const sortByProp = <T>(a: T, b: T, prop: string, order: 'asc' | 'desc' = 'asc'): number => {
+  // @ts-ignore
+  if (a[prop] > b[prop]) return order === 'asc' ? 1 : -1;
+  // @ts-ignore
+  if (a[prop] < b[prop]) return order === 'asc' ? -1 : 1;
+  return 0;
+};

--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -164,7 +164,7 @@ export default defineComponent({
       if (store.getters['filters/getCustomerSearchCriteria'] !== selectedCriteria.value) {
         store.dispatch("filters/updateCustomerSearchCriteria", selectedCriteria.value);
       }
-    }
+    };
 
     const filteredCustomers = computed(() => {
       const criteria: "name"|"debtor" = selectedCriteria.value;

--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -68,7 +68,6 @@
         <template #cell(archived)="scope">
           <div class="text-center">
             <b-badge :variant="scope.item.archived ? 'warning' : 'success'">
-              {{ scope.item.archived }}
               {{ scope.item.archived ? "Yes" : "No" }}
             </b-badge>
           </div>

--- a/pages/customers/index.vue
+++ b/pages/customers/index.vue
@@ -24,28 +24,11 @@
               placeholder="Ex.: &quot;Frontmen&quot;"
             />
           </b-col>
-          <b-col cols="6" md="2" class="mb-3">
-            <label class="employee-status__label" for="status-select">
-              Archived ?
-            </label>
-            <b-form-select
-              id="status-select"
-              v-model="selectedArchiveOption"
-              :options="searchByArchiveOptions"
-            />
-          </b-col>
-          <b-col cols="6" md="3" class="mb-3">
-            <label class="employee-status__label" for="status-select">
-              Sort:
-            </label>
-            <b-form-select
-              id="status-select"
-              v-model="selectedSortCriteria"
-              :options="sortCriteria"
-            />
-          </b-col>
-          <b-col class="ml-auto mt-auto">
-            <div class="d-flex justify-content-end">
+          <b-col cols="12" md="5" class="ml-auto mt-4">
+            <div class="d-flex justify-content-between align-items-center mt-1">
+              <b-form-checkbox v-model="selectedArchiveOption" switch class=" mr-3 ml-auto">
+                Show archived
+              </b-form-checkbox>
               <b-button v-b-modal.modal-center>
                 + New customer
               </b-button>
@@ -53,63 +36,55 @@
           </b-col>
         </b-row>
       </b-container>
-      <b-container fluid class="app-table mb-5">
-        <b-row class="app-table__top-row py-3">
-          <b-col>
-            <span class="font-weight-bold">Customers</span>
-          </b-col>
-          <b-col>
-            <span class="font-weight-bold">Archived</span>
-          </b-col>
-          <b-col class="d-flex justify-content-center">
-            <span class="font-weight-bold">Actions</span>
-          </b-col>
-        </b-row>
+      <b-table
+        class="mt-3 app-table timesheet-table"
+        responsive
+        head-variant="dark"
+        :items="filteredCustomers"
+        :fields="fields"
+        :sort-compare="sortCompare"
+        sort-by="customers"
+        no-sort-reset
+      >
+        <!-- Only the columns we want to customize need to be added
+        the ones that are missing are handled by default strategy -->
+        <template #head(archived)="data">
+          <div class="text-center">
+            {{ data.label }}
+          </div>
+        </template>
+        <template #head(actions)="data">
+          <div class="text-right">
+            {{ data.label }}
+          </div>
+        </template>
 
-        <b-row
-          v-if="!filteredCustomers.length"
-          class="app-table__row employee-row p-3 mr-0 align-items-center justify-content-center"
-        >
-          <b-icon-person-x class="mr-2" />
-          No customers found.
-        </b-row>
-
-        <b-row
-          v-for="customer in filteredCustomers"
-          v-else
-          :key="customer.id"
-          class="app-table__row py-3"
-        >
-          <b-col>
-            <div class="font-weight-bold">
-              {{ customer.name }}
-              <b-badge v-if="customer.isDefault">
-                Default
-              </b-badge>
-            </div>
-            <div>
-              {{ customer.debtor }}
-            </div>
-          </b-col>
-
-          <b-col>
-            <div class="font-weight-bold">
-              <b-badge :variant="customer.archived ? 'warning' : 'success'">
-                {{ customer.archived ? "Yes" : "No" }}
-              </b-badge>
-            </div>
-          </b-col>
-
-          <b-col cols-md="4" class="d-flex justify-content-end">
+        <template #cell(customers)="scope">
+          <strong>{{ scope.item.name }}</strong>
+          <b-badge v-if="scope.item.isDefault">
+            Default
+          </b-badge>
+        </template>
+        <template #cell(archived)="scope">
+          <div class="text-center">
+            <b-badge :variant="scope.item.archived ? 'warning' : 'success'">
+              {{ scope.item.archived }}
+              {{ scope.item.archived ? "Yes" : "No" }}
+            </b-badge>
+          </div>
+        </template>
+        <template #cell(actions)="scope">
+          <div class="text-right">
             <nuxt-link
-              :to="`/customers/${customer.id}`"
+              :to="`/customers/${scope.item.id}`"
               class="btn btn-primary align-self-center"
+              title="Manage Customer"
             >
               Manage Customer
             </nuxt-link>
-          </b-col>
-        </b-row>
-      </b-container>
+          </div>
+        </template>
+      </b-table>
     </div>
     <b-modal
       id="modal-center"
@@ -157,42 +132,33 @@ export default defineComponent({
     store.dispatch("customers/getCustomers");
 
     const searchTerm = ref<string>("");
-    const searchByArchiveOptions: { value: boolean | null, text: string }[] = [ {value: null, text: "Select"}, {value: false, text: "No"}, {value: true, text: "Yes"}] ;
     const searchCriteria: { value: "name"|"debtor"; text: string; }[] = [
       { value: "name", text: "Customer name" },
       { value: "debtor", text: "Debtor name" },
     ];
-    const sortCriteria: { value: string|null; text: string; }[] = [
-      { value: null, text: "None" },
-      { value: "name-asc", text: "Name A->Z" },
-      { value: "name-desc", text: "Name Z->A" },
-      { value: "debtor-asc", text: "Debtor A->Z" },
-      { value: "debtor-desc", text: "Debtor Z->A" },
+
+    const fields = [
+      { key: 'name', label: 'Customers', sortable: true },
+      { key: 'debtor', label: 'Debtors', sortable: true },
+      { key: 'archived', label: 'Archived', sortable: false },
+      { key: 'actions', label: 'Actions', sortable: false }
     ];
     const selectedCriteria = ref<"name"|"debtor">(searchCriteria[0].value);
-    const selectedSortCriteria = ref<string|null>(null);
-    const selectedArchiveOption= ref<boolean | null>(searchByArchiveOptions[0].value);
+    const selectedArchiveOption= ref<boolean>(false);
 
     const filteredCustomers = computed(() => {
       const criteria: "name"|"debtor" = selectedCriteria.value;
 
       const customerList = customers.value || [];
 
-      const notArchived = customerList.filter((customer: Customer) => {
-          if (selectedArchiveOption.value === null) return true
-          return !!customer.archived === selectedArchiveOption.value
+      const notArchived = selectedArchiveOption.value ? [...customerList] : customerList.filter((customer: Customer) => {
+          return !customer.archived;
         });
 
-      let filtered: Customer[] = !searchTerm.value ? [...notArchived] : notArchived?.filter((customer: Customer) => {
+      const filtered: Customer[] = !searchTerm.value ? [...notArchived] : notArchived?.filter((customer: Customer) => {
           if (!customer[criteria]) return customer;
           return queryOnString(customer[criteria], searchTerm.value);
         });
-
-      if (selectedSortCriteria.value) {
-        const criteria = selectedSortCriteria.value.split("-") as [string, "asc"|"desc"];
-        const [prop, order] = criteria;
-        filtered = filtered.sort((a,b) => sortByProp<Customer>(a, b, prop, order));
-      }
 
       return filtered;
     });
@@ -218,15 +184,18 @@ export default defineComponent({
       newCustomer.value.isDefault = false;
     };
 
+    const sortCompare = (a: Customer, b: Customer, key: "name"|"debtor") => {
+      return sortByProp<Customer>(a, b, key);
+    }
+
     return {
-      selectedSortCriteria,
+      fields,
+      sortCompare,
       filteredCustomers,
       searchTerm,
       searchCriteria,
-      searchByArchiveOptions,
       selectedArchiveOption,
       selectedCriteria,
-      sortCriteria,
       newCustomer,
       canAddCustomer,
       addCustomer,

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -177,16 +177,29 @@ export default defineComponent({
         }))
     );
 
-    const selectedCustomers = ref<Customer[]>([]);
+    const selectedCustomers = ref<Customer[]>(store.getters['filters/getEmployeeFilterByCustomer']);
 
-    const statusSelected = ref<string>("all");
+    const statusSelected = ref<string>(store.getters['filters/getEmployeeFilterBy']);
     const statusOptions = [
       { value: "all", text: "All" },
       { value: "active", text: "Active" },
       { value: "incative", text: "Inactive" },
     ];
 
-    const searchInput = ref<string>("");
+    const searchInput = ref<string>(store.getters['filters/getEmployeeSearchTerm']);
+
+
+    const handleFilterUpdates = () => {
+      if (store.getters['filters/getEmployeeSearchTerm'] !== searchInput.value) {
+        store.dispatch("filters/updateEmployeeSearchTerm", searchInput.value);
+      }
+      if (store.getters['filters/getEmployeeFilterBy'] !== statusSelected.value) {
+        store.dispatch("filters/updateEmployeeFilterBy", statusSelected.value);
+      }
+      if (store.getters['filters/getEmployeeFilterByCustomer'] !== selectedCustomers.value) {
+        store.dispatch("filters/updateEmployeeFilterByCustomer", selectedCustomers.value);
+      }
+    };
 
     const employeeStatusChecker = (status: string, employee: Employee) => {
       if (status === "all") return true;
@@ -222,6 +235,8 @@ export default defineComponent({
         !selectedCustomers.value.length
       )
         return [...employees.value];
+
+      handleFilterUpdates();
 
       return employees.value.filter(
         (employee) => {

--- a/pages/timesheets/index.vue
+++ b/pages/timesheets/index.vue
@@ -14,7 +14,9 @@
           class="filter__select"
         >
           <template #first>
-            <b-form-select-option :value="null"> All </b-form-select-option>
+            <b-form-select-option :value="null">
+              All
+            </b-form-select-option>
           </template>
         </b-form-select>
       </b-form-group>
@@ -25,6 +27,7 @@
         :items="tableData.items"
         :fields="tableData.fields"
         :sort-compare="sortCompare"
+        :sort-desc.sync="sortDescending"
         :filter="filter"
         sort-by="id"
         no-sort-reset
@@ -90,13 +93,17 @@ export default defineComponent({
       }))
       .sort((a, b) => a.text.localeCompare(b.text));
 
-    const selected = ref(null);
+    const sortDescending= ref<boolean>(store.getters['filters/getTimesheetSortDescending']);
+    const selected = ref(store.getters['filters/getTimesheetFilterBy']);
     const getSelected = computed(() => selected.value);
 
     const weeksBefore = 6;
     const weeksAfter = 2;
 
-    const tableData = computed(() => store.state.timesheets.timesheetTableData);
+    const tableData = computed(() => {
+      handleFilterUpdates();
+      return store.state.timesheets.timesheetTableData;
+    });
     store.dispatch("timesheets/getTableData", {
       weeksBefore,
       weeksAfter,
@@ -108,6 +115,15 @@ export default defineComponent({
       startTimestamp: number
     ) => {
       router.push(`/timesheets/${employeeId}/${startTimestamp}`);
+    };
+
+    const handleFilterUpdates = () => {
+      if (store.getters['filters/getTimesheetFilterBy'] !== selected.value) {
+        store.dispatch("filters/updateTimesheetFilterBy", selected.value);
+      }
+      if (store.getters['filters/getTimesheetSortDescending'] !== sortDescending.value) {
+        store.dispatch("filters/updateTimesheetSortDescending", sortDescending.value);
+      }
     };
 
     const sortCompare = (
@@ -124,6 +140,7 @@ export default defineComponent({
       options,
       selected,
       filter: getSelected,
+      sortDescending,
       recordStatus,
       openEmployeeTimesheetPage,
       tableData,

--- a/pages/timesheets/index.vue
+++ b/pages/timesheets/index.vue
@@ -21,6 +21,7 @@
       <b-table
         class="mt-3 app-table timesheet-table"
         responsive
+        head-variant="dark"
         :items="tableData.items"
         :fields="tableData.fields"
         :sort-compare="sortCompare"
@@ -141,14 +142,6 @@ export default defineComponent({
   @media (min-width: 576px) {
     width: 25%;
   }
-}
-
-.timesheet-table > .table.b-table > thead > tr > .table-b-table-default,
-.timesheet-table > .table.b-table > thead > tr > th {
-  background: var(--color-primary);
-  color: var(--color-primary-text);
-  padding-top: 1rem;
-  padding-bottom: 1rem;
 }
 
 .container--cell {

--- a/store/filters/actions.ts
+++ b/store/filters/actions.ts
@@ -1,0 +1,21 @@
+import { ActionTree } from 'vuex';
+
+const actions: ActionTree<FiltersStoreState, RootStoreState> = {
+  updateCustomerIsArchived({ commit }, payload: boolean) {
+    commit('setCustomerIsArchived', payload);
+  },
+  updateCustomerSearchTerm({ commit }, payload: string) {
+    commit('setCustomerSearchTerm', payload);
+  },
+  updateCustomerSearchCriteria({ commit }, payload: 'name'|'debtor') {
+    commit('setCustomerSearchCriteria', payload);
+  },
+  updateCustomerSortDescending({ commit }, payload: boolean) {
+    commit('setCustomerSortDescending', payload);
+  },
+  updateCustomerSortBy({ commit }, payload: string) {
+    commit('setCustomerSortBy', payload);
+  },
+};
+
+export default actions;

--- a/store/filters/actions.ts
+++ b/store/filters/actions.ts
@@ -30,7 +30,7 @@ const actions: ActionTree<FiltersStoreState, RootStoreState> = {
   updateEmployeeFilterBy({ commit }, payload: string) {
     commit('setEmployeeFilterBy', payload);
   },
-  updateEmployeeFilterByCustomer({ commit }, payload: string) {
+  updateEmployeeFilterByCustomer({ commit }, payload: string[]) {
     commit('setEmployeeFilterByCustomer', payload);
   },
   updateEmployeeSearchTerm({ commit }, payload: string) {

--- a/store/filters/actions.ts
+++ b/store/filters/actions.ts
@@ -1,6 +1,7 @@
 import { ActionTree } from 'vuex';
 
 const actions: ActionTree<FiltersStoreState, RootStoreState> = {
+  // Customers
   updateCustomerIsArchived({ commit }, payload: boolean) {
     commit('setCustomerIsArchived', payload);
   },
@@ -15,6 +16,14 @@ const actions: ActionTree<FiltersStoreState, RootStoreState> = {
   },
   updateCustomerSortBy({ commit }, payload: string) {
     commit('setCustomerSortBy', payload);
+  },
+
+  // Timesheets
+  updateTimesheetSortDescending({ commit }, payload: boolean) {
+    commit('setTimesheetSortDescending', payload);
+  },
+  updateTimesheetFilterBy({ commit }, payload: string) {
+    commit('setTimesheetFilterBy', payload);
   },
 };
 

--- a/store/filters/actions.ts
+++ b/store/filters/actions.ts
@@ -25,6 +25,17 @@ const actions: ActionTree<FiltersStoreState, RootStoreState> = {
   updateTimesheetFilterBy({ commit }, payload: string) {
     commit('setTimesheetFilterBy', payload);
   },
+
+  // Timesheets
+  updateEmployeeFilterBy({ commit }, payload: string) {
+    commit('setEmployeeFilterBy', payload);
+  },
+  updateEmployeeFilterByCustomer({ commit }, payload: string) {
+    commit('setEmployeeFilterByCustomer', payload);
+  },
+  updateEmployeeSearchTerm({ commit }, payload: string) {
+    commit('setEmployeeSearchTerm', payload);
+  },
 };
 
 export default actions;

--- a/store/filters/getters.ts
+++ b/store/filters/getters.ts
@@ -29,8 +29,20 @@ const getters: GetterTree<FiltersStoreState, RootStoreState> = {
 
   getTimesheetSortDescending(state) {
     return state.timesheetFilters.sortDescending;
-  }
+  },
 
+  // Employee
+  getEmployeeFilterBy(state) {
+    return state.employeeFilters.filterBy;
+  },
+
+  getEmployeeFilterByCustomer(state) {
+    return state.employeeFilters.filterByCustomer;
+  },
+
+  getEmployeeSearchTerm(state) {
+    return state.employeeFilters.searchTerm;
+  },
 }
 
 export default getters;

--- a/store/filters/getters.ts
+++ b/store/filters/getters.ts
@@ -1,6 +1,7 @@
 import { GetterTree } from "vuex";
 
 const getters: GetterTree<FiltersStoreState, RootStoreState> = {
+  // Customers
   getIsCustomerArchived(state) {
     return state.customerFilters.archived;
   },
@@ -18,16 +19,16 @@ const getters: GetterTree<FiltersStoreState, RootStoreState> = {
   },
 
   getCustomerSearchCriteria(state) {
-    console.log("vlad", state);
     return state.customerFilters.searchCriteria;
   },
 
-  getTimesheetSortBy(state) {
-    return state.timesheetFilters.sortBy;
+  // Timesheets
+  getTimesheetFilterBy(state) {
+    return state.timesheetFilters.filterBy;
   },
 
-  getTimesheetSearchTerm(state) {
-    return state.timesheetFilters.searchTerm;
+  getTimesheetSortDescending(state) {
+    return state.timesheetFilters.sortDescending;
   }
 
 }

--- a/store/filters/getters.ts
+++ b/store/filters/getters.ts
@@ -1,0 +1,35 @@
+import { GetterTree } from "vuex";
+
+const getters: GetterTree<FiltersStoreState, RootStoreState> = {
+  getIsCustomerArchived(state) {
+    return state.customerFilters.archived;
+  },
+
+  getCustomerSortBy(state) {
+    return state.customerFilters.sortBy;
+  },
+
+  getCustomerSortDescending(state) {
+    return state.customerFilters.sortDescending;
+  },
+
+  getCustomerSearchTerm(state) {
+    return state.customerFilters.searchTerm;
+  },
+
+  getCustomerSearchCriteria(state) {
+    console.log("vlad", state);
+    return state.customerFilters.searchCriteria;
+  },
+
+  getTimesheetSortBy(state) {
+    return state.timesheetFilters.sortBy;
+  },
+
+  getTimesheetSearchTerm(state) {
+    return state.timesheetFilters.searchTerm;
+  }
+
+}
+
+export default getters;

--- a/store/filters/mutations.ts
+++ b/store/filters/mutations.ts
@@ -30,8 +30,8 @@ const mutations: MutationTree<FiltersStoreState> = {
   setEmployeeFilterBy(state, payload: string) {
     state.employeeFilters.filterBy = payload;
   },
-  setEmployeeFilterByCustomer(state, payload: string) {
-    state.employeeFilters.filterByCustomer = payload;
+  setEmployeeFilterByCustomer(state, payload: string[]) {
+    state.employeeFilters.filterByCustomer = [...payload];
   },
   setEmployeeSearchTerm(state, payload: string) {
     state.employeeFilters.searchTerm = payload;

--- a/store/filters/mutations.ts
+++ b/store/filters/mutations.ts
@@ -25,6 +25,17 @@ const mutations: MutationTree<FiltersStoreState> = {
   setTimesheetSortDescending(state, payload: boolean) {
     state.timesheetFilters.sortDescending = payload;
   },
+
+  // Timesheets
+  setEmployeeFilterBy(state, payload: string) {
+    state.employeeFilters.filterBy = payload;
+  },
+  setEmployeeFilterByCustomer(state, payload: string) {
+    state.employeeFilters.filterByCustomer = payload;
+  },
+  setEmployeeSearchTerm(state, payload: string) {
+    state.employeeFilters.searchTerm = payload;
+  },
 };
 
 export default mutations;

--- a/store/filters/mutations.ts
+++ b/store/filters/mutations.ts
@@ -1,0 +1,21 @@
+import { MutationTree } from 'vuex';
+
+const mutations: MutationTree<FiltersStoreState> = {
+  setCustomerIsArchived(state, payload: boolean) {
+    state.customerFilters.archived = payload;
+  },
+  setCustomerSearchTerm(state, payload: string) {
+    state.customerFilters.searchTerm = payload;
+  },
+  setCustomerSearchCriteria(state, payload: 'name'|'debtor') {
+    state.customerFilters.searchCriteria = payload;
+  },
+  setCustomerSortDescending(state, payload: boolean) {
+    state.customerFilters.sortDescending = payload;
+  },
+  setCustomerSortBy(state, payload: string) {
+    state.customerFilters.sortBy = payload;
+  },
+};
+
+export default mutations;

--- a/store/filters/mutations.ts
+++ b/store/filters/mutations.ts
@@ -1,6 +1,7 @@
 import { MutationTree } from 'vuex';
 
 const mutations: MutationTree<FiltersStoreState> = {
+  // Customers
   setCustomerIsArchived(state, payload: boolean) {
     state.customerFilters.archived = payload;
   },
@@ -15,6 +16,14 @@ const mutations: MutationTree<FiltersStoreState> = {
   },
   setCustomerSortBy(state, payload: string) {
     state.customerFilters.sortBy = payload;
+  },
+
+  // Timesheets
+  setTimesheetFilterBy(state, payload: string) {
+    state.timesheetFilters.filterBy = payload;
+  },
+  setTimesheetSortDescending(state, payload: boolean) {
+    state.timesheetFilters.sortDescending = payload;
   },
 };
 

--- a/store/filters/state.ts
+++ b/store/filters/state.ts
@@ -7,7 +7,7 @@ export default (): FiltersStoreState => ({
     sortBy: '',
   },
   timesheetFilters: {
-    searchTerm: null,
-    sortBy: '',
+    filterBy: null,
+    sortDescending: false,
   },
 });

--- a/store/filters/state.ts
+++ b/store/filters/state.ts
@@ -1,0 +1,13 @@
+export default (): FiltersStoreState => ({
+  customerFilters: {
+    archived: false,
+    searchTerm: null,
+    searchCriteria: 'name',
+    sortDescending: false,
+    sortBy: '',
+  },
+  timesheetFilters: {
+    searchTerm: null,
+    sortBy: '',
+  },
+});

--- a/store/filters/state.ts
+++ b/store/filters/state.ts
@@ -10,4 +10,9 @@ export default (): FiltersStoreState => ({
     filterBy: null,
     sortDescending: false,
   },
+  employeeFilters: {
+    searchTerm: '',
+    filterBy: 'all',
+    filterByCustomer: [],
+  },
 });

--- a/types/filters.d.ts
+++ b/types/filters.d.ts
@@ -7,7 +7,7 @@ type FiltersStoreState = {
     sortBy: string;
   },
   timesheetFilters: {
-    searchTerm: null|string;
-    sortBy: string;
+    filterBy: null|string;
+    sortDescending: boolean;
   },
 }

--- a/types/filters.d.ts
+++ b/types/filters.d.ts
@@ -10,4 +10,9 @@ type FiltersStoreState = {
     filterBy: null|string;
     sortDescending: boolean;
   },
+  employeeFilters: {
+    searchTerm: string;
+    filterBy: string;
+    filterByCustomer: string[];
+  },
 }

--- a/types/filters.d.ts
+++ b/types/filters.d.ts
@@ -1,0 +1,13 @@
+type FiltersStoreState = {
+  customerFilters: {
+    archived: boolean;
+    searchTerm: null|string;
+    searchCriteria: 'name'|'debtor';
+    sortDescending: boolean;
+    sortBy: string;
+  },
+  timesheetFilters: {
+    searchTerm: null|string;
+    sortBy: string;
+  },
+}


### PR DESCRIPTION
# Changes
Sorting order applicable to customers list.

Store filters from /customers, /employees and /timesheets

## Related issues
https://github.com/FrontMen/fm-hours/issues/91

## Changed
customers/index.vue Added a select dropdown to manage sort order. Added sorting to computed filteredCustomers
helpers.ts has a generic sortByProp function

## How to test
As an admin, navigate to /customers.
Change sort criteria, note the change in order.
Filter by keyword, note sort order is kept
Selecting "none" will return to unsorted list

Go to /customers, /employees or /timesheets and apply some filter and sort proprieties
Go to a subpage
Return - see the same filters persisting

## Screenshots
![image](https://user-images.githubusercontent.com/85111889/124912946-d72a0d80-dfee-11eb-8eab-79769bb73e1e.png)
![image](https://user-images.githubusercontent.com/85111889/124912967-ddb88500-dfee-11eb-9f65-76db2dd3326f.png)
![image](https://user-images.githubusercontent.com/85111889/124912995-e5782980-dfee-11eb-9d29-d1c488885b9d.png)

Updated images found in the comments
