### PR TITLE
Copy comment from previous week's timesheet

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -17,10 +17,10 @@ export default (employeeId: string, startTimestamp?: number) => {
   const timesheetState = computed(() => store.state.timesheets);
   const customers = computed(() => store.state.customers);
 
-  const timesheetStatus = computed(() =>
-    timesheetState.value.timesheets[0]
+  const timesheetStatus = computed(() => {
+    return timesheetState.value.timesheets[0]
       ? timesheetState.value.timesheets[0].status
-      : (recordStatus.NEW as TimesheetStatus)
+      : (recordStatus.NEW as TimesheetStatus)}
   );
 
   const timesheetDenyMessage = computed(() =>
@@ -56,6 +56,17 @@ export default (employeeId: string, startTimestamp?: number) => {
     () => timesheetState.value?.timesheets[0],
     () => {
       message.value = timesheetState.value?.timesheets[0]?.message;
+    },
+    { immediate: true }
+  );
+
+  /*
+   * Gets message from previous week's timesheet when copying.
+   */
+  watch(
+    () => store.state.timesheets.previousTimesheet,
+    () => {
+      message.value = store.state.timesheets.previousTimesheet?.message || message.value;
     },
     { immediate: true }
   );
@@ -120,6 +131,13 @@ export default (employeeId: string, startTimestamp?: number) => {
     );
     const prevStartDate = subDays(startDate, 7);
     const previousWeek = buildWeek(startOfISOWeek(prevStartDate), []);
+
+    // Dispatch getter to update message with message present in previous week.
+    store.dispatch("timesheets/getPreviousTimesheet", {
+      startDate: prevStartDate.getTime(),
+      endDate: startDate.getTime(),
+      employeeId,
+    });
 
     const previousWeekTimesheet = createWeeklyTimesheet({
       week: previousWeek,

--- a/store/timesheets/actions.ts
+++ b/store/timesheets/actions.ts
@@ -19,6 +19,22 @@ const actions: ActionTree<TimesheetsStoreState, RootStoreState> = {
     commit("setTimesheets", { timesheets });
   },
 
+  /**
+   * Action similar to #getTimesheets, but expects to store 1 single timesheet to a different point in store.
+   * Used in copying previous week, to perpetuate the comment. Payload params mandatory for accuracy in search.
+   */
+  async getPreviousTimesheet(
+    { commit },
+    payload: {
+      startDate: number;
+      endDate: number;
+      employeeId: string;
+    }
+  ) {
+    const timesheets = await this.app.$timesheetsService.getTimesheets(payload);
+    commit("setPreviousTimesheet", { timesheet: timesheets[0] });
+  },
+
   async getTableData(
     { commit },
     payload: {

--- a/store/timesheets/mutations.ts
+++ b/store/timesheets/mutations.ts
@@ -16,6 +16,10 @@ const mutations: MutationTree<TimesheetsStoreState> = {
     state.timesheets = payload.timesheets;
   },
 
+  setPreviousTimesheet: (state, payload: { timesheet: Timesheet }) => {
+    state.previousTimesheet = payload.timesheet;
+  },
+
   setTimesheetsTableData: (
     state,
     payload: { tableData: TimesheetTableData }

--- a/store/timesheets/state.ts
+++ b/store/timesheets/state.ts
@@ -3,4 +3,5 @@ export default (): TimesheetsStoreState => ({
   selectedEmployeeId: "",
   timesheets: [],
   timesheetTableData: {} as TimesheetTableData,
+  previousTimesheet: null,
 });

--- a/types/timesheets.d.ts
+++ b/types/timesheets.d.ts
@@ -20,6 +20,7 @@ interface TimesheetsStoreState {
   selectedEmployeeId: string;
   timesheets: Timesheet[];
   timesheetTableData: TimesheetTableData;
+  previousTimesheet: Timesheet|null;
 }
 
 interface Timesheet {


### PR DESCRIPTION
# Changes
Make it possible for previous week's comment to be carried over when copying the week's timesheet

## Related issues
https://github.com/FrontMen/fm-hours/issues/130

## Added
Action that retrives a single timesheet based on employee and interval, and stores it to previousTimeSheet in store. 
The more generic action would override the currently created timesheet with the old values, including the status. Rewriting it to match the new usecase risks breaking functionality, so I went with extending to a more specific scenario. 

## Changed
useTimesheets.ts #copyPreviousWeek now dispatches an event to retrieve previous timesheet. The #message is updated previousTImesheet alongside timesheet updates. 

## How to test
Fill in a week including a message.
Copy the week's values into a new timesheet
Note the comment persists into the new timesheet too. 

Fill in a week without a message
Copy the week's values into a new timesheet
Note the comment empty. 
