### PR TITLE
Fix/clear empty timesheet

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -111,6 +111,18 @@ export default (employeeId: string, startTimestamp?: number) => {
       ),
       travelProject: timesheet.value.travelProject,
     };
+
+    // if deleting the last project, clear the timesheet
+    if (timesheet.value.projects.length <= 1) {
+      store.dispatch("timesheets/deleteTimesheet", {
+        timesheetId: timesheetState.value?.timesheets[0]?.id,
+      });
+      message.value = "";
+    }
+
+    if (!unsavedWeeklyTimesheet.value.projects.length) {
+      hasUnsavedChanges.value = false;
+    }
   };
 
   const copyPreviousWeek = () => {

--- a/services/timesheets-service.ts
+++ b/services/timesheets-service.ts
@@ -75,4 +75,9 @@ export default class TimesheetsService {
 
     return { ...newTimesheet, id: newDocument.id };
   }
+
+  async deleteTimesheet(timesheetId: string) {
+    const ref = this.fire.firestore.collection("timesheets");
+    await ref.doc(timesheetId).delete();
+  }
 }

--- a/store/timesheets/actions.ts
+++ b/store/timesheets/actions.ts
@@ -70,6 +70,17 @@ const actions: ActionTree<TimesheetsStoreState, RootStoreState> = {
 
     commit("setTimesheets", { timesheets: [timesheet] });
   },
+
+  async deleteTimesheet({ commit, state }, payload: { timesheetId: string }) {
+    if (!payload.timesheetId) return;
+
+    await this.app.$timesheetsService.deleteTimesheet(payload.timesheetId);
+
+    const newTimesheets = state.timesheets.filter(
+      (timesheet) => timesheet.id !== payload.timesheetId
+    );
+    commit("setTimesheets", { timesheets: newTimesheets });
+  },
 };
 
 export default actions;


### PR DESCRIPTION
# Changes

## Related issues

Resolves #126 

## Added

- Timesheets delete actions and service method

## Removed

N/A

## Changed

- When the last project is deleted, the timesheet will also be deleted
- Reset `hasUnsavedChanges` state value

## How to test

- Add a new timesheet
- Fill in some values and leave a message
- Save
- Delete all projects
- Move to another week
- Check if the "unsaved fields" alert does not show up
- Go back to the original timesheet (the one that you just deleted)
- Create a new timesheet
- Check if the message textarea is empty 

## Screenshots

N/A
