### PR TITLE
fix: add csv file extension to end of file

### DIFF
--- a/components/reports/reports-table.vue
+++ b/components/reports/reports-table.vue
@@ -23,7 +23,7 @@ import { defineComponent } from "@vue/composition-api";
 
 export default defineComponent({
   props: {
-    csvFileName: { type: String, default: "export.csv" },
+    csvFileName: { type: String, default: "export" },
   },
   setup(props) {
     const downloadCsv = (csv: any, filename: string) => {
@@ -60,7 +60,7 @@ export default defineComponent({
         csv.push(row.join(","));
       });
 
-      downloadCsv(csv.join("\n"), props.csvFileName);
+      downloadCsv(csv.join("\n"), `${props.csvFileName}.csv`);
     }
 
     return {


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/153

## Added

Added necessary .csv extension to the files

## How to test

Go to reports page and export it in WINDOWS and MAC

## Screenshots


https://user-images.githubusercontent.com/7356299/125065495-2f761380-e0b2-11eb-804a-c84fd61cc094.mov


