### PR TITLE
feat: enable admins to add new projects / timesheets for any user

### DIFF
--- a/components/records/empty-timesheet.vue
+++ b/components/records/empty-timesheet.vue
@@ -2,7 +2,7 @@
   <div class="empty-timesheet">
     <p>There are no hours registered for this week.</p>
 
-    <template v-if="!isAdminView">
+    <template>
       <b-button v-b-modal.modal-add-project> Add a project </b-button>
       <span class="d-none d-sm-inline mx-2">or</span>
 


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/82

## Removed

Removed `if check` for admins to be able to add new timesheet's if it is empty

## How to test

If logged in as an admin, empty timesheet days for an employee now should show the same page as home screen. Home screen is where employee tries to add a timesheet of its own.

## Screenshots


https://user-images.githubusercontent.com/7356299/125615006-f8c73514-903f-4afb-ba6d-8b66f4fa4601.mov


