### PR TITLE
Add teams dropdown for employee

### DIFF
--- a/pages/employees/_employee_id.vue
+++ b/pages/employees/_employee_id.vue
@@ -150,7 +150,7 @@ export default defineComponent({
     const selectedCustomers = ref<(Customer | undefined)[]>([]);
     const hasUnsavedChanges = ref<boolean>(false);
     const errorMessage = ref("");
-    const selectedTeam = ref<string | undefined>('');
+    const selectedTeam = ref<string | null>(null);
 
     const customers = computed(() => store.state.customers.customers);
     const customerOptions = computed(() =>
@@ -172,9 +172,10 @@ export default defineComponent({
     );
 
     const teamList = computed(() => {
-      return store.getters["employees/teamList"].map((team: string) => {
+      const parsedTeam = store.getters["employees/teamList"].map((team: string) => {
         return { value: team, text: team };
       });
+      return [ { value: null, text: "Select team", }, ...parsedTeam];
     });
 
     const pageTitle = computed(() =>
@@ -204,7 +205,7 @@ export default defineComponent({
     watch(
       () => [employee.value?.team],
       () => {
-        selectedTeam.value = employee.value?.team;
+        selectedTeam.value = employee.value?.team || null;
       },
       { immediate: true }
     );

--- a/pages/employees/_employee_id.vue
+++ b/pages/employees/_employee_id.vue
@@ -11,6 +11,15 @@
         <b-row class="my-5">
           <b-col cols="12" md="5">
             <h6 class="mb-3">
+              Edit team:
+            </h6>
+            <b-form-select
+              v-model="selectedTeam"
+              :options="teamList"
+              class="mb-3"
+              @change="hasUnsavedChanges = true"
+            />
+            <h6 class="mb-3">
               Manage Projects
             </h6>
             <multiselect
@@ -140,7 +149,8 @@ export default defineComponent({
 
     const selectedCustomers = ref<(Customer | undefined)[]>([]);
     const hasUnsavedChanges = ref<boolean>(false);
-    const errorMessage = ref("")
+    const errorMessage = ref("");
+    const selectedTeam = ref<string | undefined>('');
 
     const customers = computed(() => store.state.customers.customers);
     const customerOptions = computed(() =>
@@ -161,6 +171,12 @@ export default defineComponent({
       employees.value.find((x) => x.id === employeeId)
     );
 
+    const teamList = computed(() => {
+      return store.getters["employees/teamList"].map((team: string) => {
+        return { value: team, text: team };
+      });
+    });
+
     const pageTitle = computed(() =>
       employee.value ? `Employees - ${employee.value?.name}` : "Employees"
     );
@@ -176,15 +192,22 @@ export default defineComponent({
         store.dispatch("customers/getCustomers");
       }
 
-      if (store.getters["employees/adminList"].length === 0) {
-        store.dispatch("employees/getAdminList");
-      }
+      store.dispatch("employees/getAdminList");
+      store.dispatch("employees/getTeamList");
 
       if (employee?.value?.endDate) {
         hasEndDate.value = true
         endDate.value = formatDate(getDayOnGMT(employee.value.endDate))
       }
     });
+
+    watch(
+      () => [employee.value?.team],
+      () => {
+        selectedTeam.value = employee.value?.team;
+      },
+      { immediate: true }
+    );
 
     watch(
       () => [employee.value?.projects, customers.value],
@@ -284,6 +307,7 @@ export default defineComponent({
       handleAdminToggle();
       const newEmployee = {
         ...employee.value,
+        team: selectedTeam.value,
         projects: selectedCustomers.value.map((customer) => customer!.id),
         travelAllowance: isTravelAllowed.value,
         startDate: new Date(startDate.value).getTime(),
@@ -330,6 +354,7 @@ export default defineComponent({
       employee,
       customerOptions,
       selectedCustomers,
+      selectedTeam,
       saveProjects,
       hasUnsavedChanges,
       isTravelAllowed,
@@ -341,7 +366,8 @@ export default defineComponent({
       handleProjectDelete,
       defaultCustomers,
       items,
-      handleEmployeeDelete
+      handleEmployeeDelete,
+      teamList,
     };
   },
 });

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -47,7 +47,7 @@
           />
         </b-col>
         <b-col cols="6" lg="2" class="d-flex align-items-end justify-content-end">
-          <b-button v-b-modal.modal-center >
+          <b-button v-b-modal.modal-center>
             + New employee
           </b-button>
         </b-col>
@@ -78,6 +78,7 @@
 
         <div class="font-weight-bold employee-row__name my-2 mx-3">
           {{ employee.name }}
+          <small v-if="employee.team"> - {{ employee.team }}</small>
         </div>
 
         <div class="ml-auto d-flex">

--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -124,6 +124,14 @@ export default class EmployeesService {
     return (result as unknown) as string[];
   }
 
+  public async getTeams(): Promise<string[]> {
+    const ref = this.fire.firestore.collection("teams");
+    const snapshot = await ref.get();
+    const result = snapshot.docs[0].data().teams || [];
+
+    return (result as unknown) as string[];
+  }
+
   public async updateAdminEmails(adminList: string[]): Promise<string[]> {
     const docs = await this.fire.firestore.collection("admins").get();
     const docId = await docs.docs[0].id;

--- a/store/employees/actions.ts
+++ b/store/employees/actions.ts
@@ -42,10 +42,17 @@ const actions: ActionTree<EmployeesStoreState, RootStoreState> = {
   },
 
   async getAdminList({commit, getters }) {
-    if (getters["employees/adminList"]?.length) return; // TODO Vlad maybe move to service?
+    if (getters["employees/adminList"]?.length) return;
 
     const adminList = await this.app.$employeesService.getAdminEmails();
     commit("setAdminList", adminList);
+  },
+
+  async getTeamList({commit, getters }) {
+    if (getters["employees/teamList"]?.length) return;
+
+    const teamList = await this.app.$employeesService.getTeams();
+    commit("setTeamList", teamList);
   },
 
   async updateAdminList({commit}, payload: string[]) {

--- a/store/employees/getters.ts
+++ b/store/employees/getters.ts
@@ -5,6 +5,9 @@ const getters: GetterTree<EmployeesStoreState, RootStoreState> = {
   adminList(state): string[] {
     return state.adminList;
   },
+  teamList(state): string[] {
+    return state.teamList;
+  },
 };
 
 export default getters;

--- a/store/employees/mutations.ts
+++ b/store/employees/mutations.ts
@@ -5,6 +5,10 @@ const mutations: MutationTree<EmployeesStoreState> = {
     state.adminList = payload;
   },
 
+  setTeamList: (state, payload: string[]) => {
+    state.teamList = payload;
+  },
+
   setEmployees: (state, payload: { employees: Employee[] }) => {
     state.employees = payload.employees;
   },

--- a/store/employees/state.ts
+++ b/store/employees/state.ts
@@ -1,4 +1,5 @@
 export default (): EmployeesStoreState => ({
   adminList: [],
   employees: [],
+  teamList: [],
 });

--- a/types/employee.d.ts
+++ b/types/employee.d.ts
@@ -9,6 +9,7 @@ interface Employee {
   startDate: number;
   created: number;
   bridgeUid?: string;
+  team?: string;
 }
 
 interface EmployeeStoreState {

--- a/types/employees.d.ts
+++ b/types/employees.d.ts
@@ -1,4 +1,5 @@
 interface EmployeesStoreState {
   adminList: string[];
   employees: Employee[];
+  teamList: string[];
 }


### PR DESCRIPTION
# Changes
Added dropdown to set team to an employee on employee manage view

## Related issues
https://github.com/FrontMen/fm-hours/issues/60

## Added
Added dropdown to set team to an employee on employee manage view

## How to test
1. Go to /employees
2. Go to manage on an employee
3. Change value in team dropdown and save
4. Refresh to see value retrieved or check inside firestore

## Screenshots
![image](https://user-images.githubusercontent.com/85111889/126138708-f22fe284-f09f-44f0-8d19-34e696a69e4a.png)
firestore dev example
![image](https://user-images.githubusercontent.com/85111889/126139007-1b3623b2-7add-4cec-87ef-fe371113ed00.png)
![image](https://user-images.githubusercontent.com/85111889/126138830-93fb1116-43d7-40fc-b6d4-a39e166757cd.png)
rule in firestore
![image](https://user-images.githubusercontent.com/85111889/126138903-2704dc33-aa42-450c-875f-4839ed79348c.png)

