### PR TITLE
Wrap timesheet inputs in a form for correct mobile navigation

### DIFF
--- a/pages/records.vue
+++ b/pages/records.vue
@@ -28,66 +28,68 @@
     />
 
     <template v-else>
-      <weekly-timesheet :selected-week="recordsState.selectedWeek">
-        <template #rows>
-          <weekly-timesheet-row
-            v-for="(project, index) in timesheet.projects"
-            :key="`${project.customer.id}-${recordsState.selectedWeek[0].date}`"
-            :project="timesheet.projects[index]"
-            :readonly="!isAdminView && (isReadonly || project.isExternal)"
-            :removeable="!isAdminView && !isReadonly && !project.isExternal"
-            :selected-week="recordsState.selectedWeek"
-            :value-formatter="timesheetFormatter"
-            :employee="employee"
-            @change="hasUnsavedChanges = true"
-            @remove="deleteProject(timesheet.projects[index])"
-          />
-
-          <weekly-timesheet-totals-row
-            :projects="timesheet.projects"
-            :selected-week="recordsState.selectedWeek"
-            :work-scheme="recordsState.workScheme"
-            :show-add-project-button="
-              !isReadonly && selectableCustomers.length > 0
-            "
-          />
-        </template>
-      </weekly-timesheet>
-
-      <template
-        v-if="employee && employee.travelAllowance && timesheet.travelProject"
-      >
-        <h3 class="mt-5 mb-3">
-          Travel allowance
-        </h3>
-
+      <form action="javascript:void(0);">
         <weekly-timesheet :selected-week="recordsState.selectedWeek">
           <template #rows>
             <weekly-timesheet-row
-              :key="recordsState.selectedWeek[0].date"
-              :project="timesheet.travelProject"
-              :readonly="!isAdminView && isReadonly"
-              :removable="false"
+              v-for="(project, index) in timesheet.projects"
+              :key="`${project.customer.id}-${recordsState.selectedWeek[0].date}`"
+              :project="timesheet.projects[index]"
+              :readonly="!isAdminView && (isReadonly || project.isExternal)"
+              :removeable="!isAdminView && !isReadonly && !project.isExternal"
               :selected-week="recordsState.selectedWeek"
-              :value-formatter="kilometerFormatter"
+              :value-formatter="timesheetFormatter"
               :employee="employee"
               @change="hasUnsavedChanges = true"
+              @remove="deleteProject(timesheet.projects[index])"
+            />
+
+            <weekly-timesheet-totals-row
+              :projects="timesheet.projects"
+              :selected-week="recordsState.selectedWeek"
+              :work-scheme="recordsState.workScheme"
+              :show-add-project-button="
+                !isReadonly && selectableCustomers.length > 0
+              "
             />
           </template>
         </weekly-timesheet>
-      </template>
 
-      <b-form-textarea
-        v-if="!isReadonly || message"
-        id="message-textarea"
-        v-model="message"
-        class="mt-4"
-        placeholder="Add a comment here."
-        rows="1"
-        max-rows="4"
-        :plaintext="!isAdminView && isReadonly"
-        @change="hasUnsavedChanges = true"
-      />
+        <template
+          v-if="employee && employee.travelAllowance && timesheet.travelProject"
+        >
+          <h3 class="mt-5 mb-3">
+            Travel allowance
+          </h3>
+
+          <weekly-timesheet :selected-week="recordsState.selectedWeek">
+            <template #rows>
+              <weekly-timesheet-row
+                :key="recordsState.selectedWeek[0].date"
+                :project="timesheet.travelProject"
+                :readonly="!isAdminView && isReadonly"
+                :removable="false"
+                :selected-week="recordsState.selectedWeek"
+                :value-formatter="kilometerFormatter"
+                :employee="employee"
+                @change="hasUnsavedChanges = true"
+              />
+            </template>
+          </weekly-timesheet>
+        </template>
+
+        <b-form-textarea
+          v-if="!isReadonly || message"
+          id="message-textarea"
+          v-model="message"
+          class="mt-4"
+          placeholder="Add a comment here."
+          rows="1"
+          max-rows="4"
+          :plaintext="!isAdminView && isReadonly"
+          @change="hasUnsavedChanges = true"
+        />
+      </form>
 
       <weekly-timesheet-admin-footer
         v-if="isAdminView"


### PR DESCRIPTION
# Changes
Wrapped timesheet inputs in a form, to allow correct mobile navigation

## Related issues
https://github.com/FrontMen/fm-hours/projects/1#card-62696041

## Changed
records.vue rows timesheet rows, travel allowance rows and comment wrapped inside a form to allow for easy mobile navigation

## How to test
1. Access / with mobile
2. Fill in value and hit next on keyboard
3. Check that next allows you to navigate all the way to comment
4. Other accessibility mobile navigation not included in this story
5. Visual changes not included
