### PR TITLE
Unapprove button for admin

### DIFF
--- a/components/timesheets/weekly-timesheet-admin-footer.vue
+++ b/components/timesheets/weekly-timesheet-admin-footer.vue
@@ -1,9 +1,10 @@
 <template>
-  <div class="weekly-timesheet-footer">
+  <div class="weekly-timesheet-footer mb-3">
     <div>
-      <span v-if="lastSaved" class="mr-3"
-        >Last saved: {{ lastSavedLabel }}</span
-      >
+      <span
+        v-if="lastSaved"
+        class="mr-3"
+      >Last saved: {{ lastSavedLabel }}</span>
       <b-spinner v-if="isSaving" small />
 
       <b-button
@@ -37,6 +38,14 @@
 
     <template v-else>
       <template v-if="isApproved">
+        <b-button
+          class="mr-3 ml-3"
+          variant="danger"
+          :disabled="isSaving"
+          @click="handleUndoApproveClick"
+        >
+          Undo approval
+        </b-button>
         <strong>APPROVED</strong>
         <b-icon class="ml-1" icon="check-circle-fill" variant="success" />
       </template>
@@ -87,6 +96,7 @@ export default defineComponent({
 
     const handleSaveClick = () => emit("save");
     const handleApproveClick = () => emit("approve");
+    const handleUndoApproveClick = () => emit("unapprove");
 
     const isApproved = computed(() => props.status === recordStatus.APPROVED);
     const isDenied = computed(() => props.status === recordStatus.DENIED);
@@ -114,6 +124,7 @@ export default defineComponent({
     return {
       handleSaveClick,
       handleApproveClick,
+      handleUndoApproveClick,
       isClosed,
       isApproved,
       isDenied,

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -98,6 +98,7 @@
         :status="timesheetStatus"
         @save="saveTimesheet(recordStatus.PENDING)"
         @approve="saveTimesheet(recordStatus.APPROVED)"
+        @unapprove="saveTimesheet(recordStatus.NEW)"
       />
 
       <weekly-timesheet-footer
@@ -250,7 +251,7 @@ export default defineComponent({
         })),
       ];
     });
- 
+
     return {
       employee: selectedEmployee,
       selectableCustomers,


### PR DESCRIPTION
# Changes
Admin can un-approve a timesheet previously approved

## Related issues
https://github.com/FrontMen/fm-hours/issues/56

## Added
@unapprove event in weekly-timesheet-admin-footer

## Changed
* Unapprove button with an approved timesheet in admin view
* @unapprove event triggers saving timesheet with status NEW
* bottom margin to in weekly-timesheet-admin-footer for better layout

## How to test
1. As an admin, go to /timesheets and visit an approved timesheet
2. Hit the unapprove button (undo approval)
3. Check the timesheet is NEW in /timesheets and/or firestore


## Screenshots
![image](https://user-images.githubusercontent.com/85111889/126299570-1e657dc9-06cd-44a0-9c10-fe82e80efeac.png)
