### PR TITLE
feat: add edit/display of name/email in the employee overview page

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,10 @@
-functions/**/*
-node_modules/**/*
+# ignore the firebase functions
+functions
+
+# ignore node modules
+node_modules
+
+# ignore build files and configs
+dist
+static
+.nuxt

--- a/helpers/email.ts
+++ b/helpers/email.ts
@@ -31,3 +31,5 @@ export const buildEmailData = ({
     html,
   };
 };
+
+export const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/package.json
+++ b/package.json
@@ -9,17 +9,21 @@
     "generate": "nuxt-ts generate",
     "test": "jest",
     "test:types": "tsc --noEmit",
-    "lint:eslint": "eslint --ext .js,.vue . --ignore-path .gitignore .",
-    "lint:prettier": "prettier \"**/*.js\" \"**/*.vue\" --check --ignore-path .gitignore .",
+    "lint:eslint": "eslint --ext .js,.vue --ignore-path .eslintignore .",
+    "lint:eslint:hook": "eslint --ext .js,.vue --ignore-path .eslintignore",
+    "lint:prettier": "prettier \"**/*.js\" \"**/*.vue\" --check --ignore-path .eslintignore .",
+    "lint:prettier:hook": "prettier --write",
     "lint": "npm run lint:eslint && npm run lint:prettier",
-    "format:eslint": "eslint --ext .js,.vue . --fix --ignore-path .gitignore .",
-    "format:prettier": "prettier \"**/*.js\" \"**/*.vue\" --write --ignore-path .gitignore .",
+    "format:eslint": "eslint --ext .js,.vue . --fix --ignore-path .eslintignore .",
+    "format:prettier": "prettier \"**/*.js\" \"**/*.vue\" --write --ignore-path .eslintignore .",
     "format": "npm run format:eslint && npm run format:prettier"
   },
   "lint-staged": {
     "*.{js,ts,vue}": [
-      "eslint --fix",
-      "prettier --write"
+      "npm run lint:eslint:hook"
+    ],
+    "*.{js, ts}": [
+      "npm run test:types"
     ]
   },
   "eslintConfig": {
@@ -32,7 +36,7 @@
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "tsc --noEmit && lint-staged"
+      "pre-commit": "lint-staged"
     }
   },
   "dependencies": {

--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="content-wrapper mt-5">
     <b-container class="mx-0 px-0 mb-3" fluid>
-      <b-row no-gutters="true">
+      <b-row :no-gutters="true">
         <b-col cols="6" lg="3" class="pl-0">
           <label class="employee-status__label" for="employee-search">
             Search by employee name:


### PR DESCRIPTION
# Changes

Display of employee name and email in the employee overview page

## Related issues

https://github.com/FrontMen/fm-hours/issues/125

## Added

* email field / name field
* basic email regex
* basic form validation for name and email

## Changed

* fixed issue with boolean type on styling prop
* fixed the git-hooks to correctly lint (and only lint) the changed files on commit
* removed prettier on git-hook (for now)
* set typescript compiler type checking to only check ts/js files that are committed (during git-commit hook)
* eslint and prettier now _correctly_ use the `.eslintignore` instead of the `.gitignore`
* fix formatting in `_employee_id.vue`

## How to test

* Open an employee in the employee overview
* you can now edit and view the name and email of an employee
* save changes
* refresh page to view (check firebase to validate save)

Further:

* committing new changes now correctly checks linting and types 

## Screenshots

![image](https://user-images.githubusercontent.com/4496638/126635714-6d65eefd-8bd8-4888-b5fe-674f5ebb1e13.png)
