### PR TITLE
Feature feedback link

### DIFF
--- a/components/app/top-bar.vue
+++ b/components/app/top-bar.vue
@@ -9,13 +9,19 @@
                 src="@/assets/images/logo-dark.png"
                 alt="frontmen logo"
                 @click="handleLogoClick"
-              />
+              >
 
               <div
                 v-if="isAdmin"
                 v-b-toggle.sidebar-1
                 class="top-bar__hamburger ml-4"
               />
+
+              <a
+                href="https://docs.google.com/forms/d/e/1FAIpQLSdl99lxgE8VDMfHXX_O35Lm8JeJmgA-yDYmG5mMHGWWdT7PrQ/viewform?usp=sf_link"
+                target="_blank"
+                class="text-white ml-3"
+              >Feedback</a>
             </div>
           </b-col>
 


### PR DESCRIPTION
# Changes

Added feedback link in topbar. 
Visible on all pages, but sufficiently out of sight. 
Placed to the lefthand side not to compete with user name for space or be too distracting (increased size on text thus weight in that area), yet it stays clear and easy to find.
Simple external link, nothing fancy. 

## Related issues
https://github.com/FrontMen/fm-hours/issues/179

## How to test
Go to app
Click on "feedback"
it opens a google form in a new tab

## Screenshots
![image](https://user-images.githubusercontent.com/85111889/126639535-35e7ecfe-eea5-4d33-9aac-1b36683fcc8d.png)
![image](https://user-images.githubusercontent.com/85111889/126639569-26ac3c3b-bab4-40a1-8bbd-feed7d5c5cbe.png)
![image](https://user-images.githubusercontent.com/85111889/126639594-858fe527-9bb9-408c-a235-324a942a2979.png)

