### PR TITLE
Feat/show leave days

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -16,6 +16,7 @@
     </b-col>
 
     <b-tooltip
+      v-if="removable"
       id="tooltip-confirmation"
       ref="tooltip"
       custom-class="tooltip-opacity"

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -6,9 +6,9 @@ import {recordStatus} from '~/helpers/record-status';
 import {
   createWeeklyTimesheet,
   timesheetFormatter,
-  kilometerFormatter,
-} from '~/helpers/timesheet';
-import {buildEmailData} from '~/helpers/email';
+  kilometerFormatter, createLeaveProject,
+} from "~/helpers/timesheet";
+import { buildEmailData } from "~/helpers/email";
 
 export default (
   employeeId: string,
@@ -42,6 +42,7 @@ export default (
 
   const timesheet = ref<WeeklyTimesheet>({
     projects: [],
+    leaveDays: null,
     travelProject: null,
   });
 
@@ -126,6 +127,7 @@ export default (
       projects: timesheet.value.projects.filter(
         (proj) => proj.customer.id !== project.customer.id
       ),
+      leaveDays: timesheet.value.leaveDays,
       travelProject: timesheet.value.travelProject,
     };
 
@@ -158,6 +160,7 @@ export default (
 
     const previousWeekTimesheet = createWeeklyTimesheet({
       week: previousWeek,
+      leaveDays: createLeaveProject(recordsState.value.selectedWeek, recordsState.value.workScheme),
       timeRecords: recordsState.value.timeRecords,
       travelRecords: recordsState.value.travelRecords,
       workScheme: recordsState.value.workScheme,
@@ -180,6 +183,7 @@ export default (
           ...project,
           ids: new Array(7).fill(null),
         })),
+      leaveDays: previousWeekTimesheet.leaveDays,
       travelProject: {
         ...previousWeekTimesheet.travelProject!,
         ids: new Array(7).fill(null),
@@ -194,6 +198,7 @@ export default (
   watch(
     () => [
       recordsState.value.selectedWeek,
+      recordsState.value.leaveDays,
       recordsState.value.timeRecords,
       recordsState.value.travelRecords,
     ],
@@ -209,6 +214,7 @@ export default (
 
       const newTimesheet = createWeeklyTimesheet({
         week: recordsState.value.selectedWeek,
+        leaveDays: createLeaveProject(recordsState.value.selectedWeek, recordsState.value.workScheme),
         timeRecords: recordsState.value.timeRecords,
         travelRecords: recordsState.value.travelRecords,
         workScheme: recordsState.value.workScheme,

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -198,7 +198,6 @@ export default (
   watch(
     () => [
       recordsState.value.selectedWeek,
-      recordsState.value.leaveDays,
       recordsState.value.timeRecords,
       recordsState.value.travelRecords,
     ],

--- a/helpers/dates.ts
+++ b/helpers/dates.ts
@@ -64,7 +64,7 @@ export function checkNonWorkingDays(
   days: WeekDate[],
   customHolidays: string[],
   workScheme?: WorkScheme[]
-) {
+): WeekDate[] {
   return days.map((day) => {
     const isCustomHoliday = customHolidays.includes(day.date);
 

--- a/helpers/timesheet.ts
+++ b/helpers/timesheet.ts
@@ -105,7 +105,7 @@ export const createLeaveProject = (
       isBillable: false,
       isDefault: false,
     },
-    ids: hours.map(_ => uuidv4()),
+    ids: new Array(hours.length).fill(null),
     values: hours,
     isExternal: false,
   }: null;
@@ -113,12 +113,6 @@ export const createLeaveProject = (
 
 const findLeaveHoursByDate = (leaveDay: WeekDate, workScheme: WorkScheme[]): number =>
   workScheme.find((workSchemeDate: WorkScheme) => workSchemeDate.date === leaveDay.date)?.absenceHours ?? 0
-
-function uuidv4() {
-  return '00-0-4-1-000'.replace(/[^-]/g,
-    (s:any) => ((Math.random() + ~~s) * 0x10000 >> s).toString(16).padStart(4, '0')
-  );
-}
 
 const findRecordByDate = (
   weekDay: WeekDate,

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -85,6 +85,28 @@
           </weekly-timesheet>
         </template>
 
+        <template v-if="timesheet.leaveDays" class="mb-3">
+          <h3 class="mt-5 mb-3">
+            Leave days
+          </h3>
+          <div class="pb-5">
+            <weekly-timesheet :selected-week="recordsState.selectedWeek">
+              <template #rows>
+                <weekly-timesheet-row
+                  :key="recordsState.selectedWeek[0].date"
+                  :project="timesheet.leaveDays"
+                  :readonly="true"
+                  :removable="false"
+                  :selected-week="recordsState.selectedWeek"
+                  :value-formatter="timesheetFormatter"
+                  :employee="employee"
+                  @change="hasUnsavedChanges = true"
+                />
+              </template>
+            </weekly-timesheet>
+          </div>
+        </template>
+
         <b-form-textarea
           v-if="!isReadonly || message"
           id="message-textarea"
@@ -130,28 +152,6 @@
       >
         {{ timesheetDenyMessage }}
       </b-alert>
-    </template>
-
-    <template v-if="timesheet.leaveDays" class="mb-3">
-      <h3 class="mt-5 mb-3">
-        Leave days
-      </h3>
-      <div class="pb-5">
-        <weekly-timesheet :selected-week="recordsState.selectedWeek">
-          <template #rows>
-            <weekly-timesheet-row
-              :key="recordsState.selectedWeek[0].date"
-              :project="timesheet.leaveDays"
-              :readonly="true"
-              :removable="false"
-              :selected-week="recordsState.selectedWeek"
-              :value-formatter="timesheetFormatter"
-              :employee="employee"
-              @change="hasUnsavedChanges = true"
-            />
-          </template>
-        </weekly-timesheet>
-      </div>
     </template>
 
     <select-project-dialog

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -277,7 +277,9 @@ export default defineComponent({
     });
 
     function autoSave() {
-      timesheet.saveTimesheet(recordStatus.NEW as TimesheetStatus);
+      if (timesheet.hasUnsavedChanges){
+        timesheet.saveTimesheet(recordStatus.NEW as TimesheetStatus);
+      }
     }
 
     return {

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -65,7 +65,9 @@
         <template
           v-if="employee && employee.travelAllowance && timesheet.travelProject"
         >
-          <h3 class="mt-5 mb-3">Travel allowance</h3>
+          <h3 class="mt-5 mb-3">
+            Travel allowance
+          </h3>
 
           <weekly-timesheet :selected-week="recordsState.selectedWeek">
             <template #rows>
@@ -128,6 +130,28 @@
       >
         {{ timesheetDenyMessage }}
       </b-alert>
+    </template>
+
+    <template v-if="timesheet.leaveDays" class="mb-3">
+      <h3 class="mt-5 mb-3">
+        Leave days
+      </h3>
+      <div class="pb-5">
+        <weekly-timesheet :selected-week="recordsState.selectedWeek">
+          <template #rows>
+            <weekly-timesheet-row
+              :key="recordsState.selectedWeek[0].date"
+              :project="timesheet.leaveDays"
+              :readonly="true"
+              :removable="false"
+              :selected-week="recordsState.selectedWeek"
+              :value-formatter="timesheetFormatter"
+              :employee="employee"
+              @change="hasUnsavedChanges = true"
+            />
+          </template>
+        </weekly-timesheet>
+      </div>
     </template>
 
     <select-project-dialog

--- a/store/records/actions.ts
+++ b/store/records/actions.ts
@@ -60,8 +60,10 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
       employeeId: payload.employeeId,
     });
 
-    const travelRecords =
-      await this.app.$travelRecordsService.getEmployeeRecords({
+    const leaveDays: WeekDate[] = selectedWeek.filter((day: WeekDate) => day.isLeaveDay)
+
+    const travelRecords = await this.app.$travelRecordsService.getEmployeeRecords(
+      {
         employeeId: payload.employeeId,
       });
 
@@ -69,6 +71,7 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
     commit('setRecords', {
       timeRecords,
       travelRecords,
+      leaveDays,
       selectedWeek,
       workScheme: workSchemeResult || [],
     });

--- a/store/records/mutations.ts
+++ b/store/records/mutations.ts
@@ -15,6 +15,7 @@ const mutations: MutationTree<RecordsStoreState> = {
     payload: {
       timeRecords: TimeRecord[];
       travelRecords: TravelRecord[];
+      leaveDays: WeekDate[];
       selectedWeek: WeekDate[];
       workScheme: WorkScheme[];
     }
@@ -23,6 +24,7 @@ const mutations: MutationTree<RecordsStoreState> = {
     if (payload.travelRecords) state.travelRecords = payload.travelRecords;
     if (payload.selectedWeek) state.selectedWeek = payload.selectedWeek;
     if (payload.workScheme) state.workScheme = payload.workScheme;
+    if (payload.leaveDays) state.leaveDays = payload.leaveDays;
   },
 
   updateRecords(

--- a/store/records/state.ts
+++ b/store/records/state.ts
@@ -5,5 +5,6 @@ export default (): RecordsStoreState => ({
   selectedWeek: [],
   timeRecords: [],
   travelRecords: [],
+  leaveDays: [],
   workScheme: [],
 });

--- a/types/records.d.ts
+++ b/types/records.d.ts
@@ -35,6 +35,7 @@ interface TimesheetProject {
 
 interface WeeklyTimesheet {
   projects: TimesheetProject[];
+  leaveDays: TimesheetProject | null;
   travelProject: TimesheetProject | null;
 }
 
@@ -43,6 +44,7 @@ interface RecordsStoreState {
   isSaving: boolean;
   lastSaved: Date | null;
   selectedWeek: WeekDate[];
+  leaveDays: WeekDate[];
   timeRecords: TimeRecord[];
   travelRecords: TravelRecord[];
   workScheme: WorkScheme[];


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/46

## Added

Added new "leaveDays" field to WeeklyTimeSheet class. Which derives information through bridge api's "abscence hours". 

## How to test
Change work-scheme-service.ts to the following. This will makes the 26th of july absence for 4 hours.

```     
return response.data.map((ws) => {
        if (ws.date === "2021-07-26"){
          return {
            date: ws.date,
            theoreticalHours: ws.theoretical_hours,
            absenceHours: 4,
            workHours: ws.work_hours,
            holiday: ws.holiday,
          }
        }
        return {
          date: ws.date,
          theoreticalHours: ws.theoretical_hours,
          absenceHours: ws.absence_hours,
          workHours: ws.work_hours,
          holiday: ws.holiday,
        }

      });
```

## Screenshots


https://user-images.githubusercontent.com/7356299/126787919-847b6c02-4007-4f88-8ea1-248b44a2d65b.mov

