### PR TITLE
Feature/keyboard shortcuts

### DIFF
--- a/components/records/empty-timesheet.vue
+++ b/components/records/empty-timesheet.vue
@@ -3,7 +3,13 @@
     <p>There are no hours registered for this week.</p>
 
     <template>
-      <b-button v-b-modal.modal-add-project>Add a project</b-button>
+      <b-button
+        v-b-modal.modal-add-project
+        v-b-tooltip.hover
+        title="Or use 'n' to add project"
+      >
+        Add a project
+      </b-button>
       <span class="d-none d-sm-inline mx-2">or</span>
 
       <b-button @click="handleCopyPreviousWeekClick">

--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -19,7 +19,11 @@
         {{ weekLabel }}
       </h2>
       <b-button-group class="navigation-buttons__date-group">
-        <b-button @click="handlePreviousClick()">
+        <b-button
+          v-b-tooltip.hover
+          title="Or use keyboard left to go to previous week"
+          @click="handlePreviousClick()"
+        >
           <b-icon icon="arrow-left" />
         </b-button>
         <b-button
@@ -29,7 +33,12 @@
           <b-icon icon="calendar2-date" />
         </b-button>
 
-        <b-button :disabled="weekDifference > 3" @click="handleNextClick()">
+        <b-button
+          v-b-tooltip.hover
+          :disabled="weekDifference > 3"
+          title="Or use keyboard right to go to next week"
+          @click="handleNextClick()"
+        >
           <b-icon icon="arrow-right" />
         </b-button>
       </b-button-group>

--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -40,6 +40,7 @@
 <script lang="ts">
 import {computed, defineComponent, PropType} from "@nuxtjs/composition-api";
 import differenceInCalendarWeeks from "date-fns/differenceInCalendarWeeks";
+import hotkeys from 'hotkeys-js';
 
 import {getWeekRange, getDateLabel, getDayOnGMT} from "~/helpers/dates";
 
@@ -54,6 +55,10 @@ export default defineComponent({
       type: Boolean,
       default: false,
     },
+  },
+  beforeDestroy() {
+    // Somehow, correctly only unbinds specifically "*". If other components, in a shared scope, use it, it will unbind it. Does not unbind other keys.
+    hotkeys.unbind('*');
   },
   setup(props, {emit}) {
     const handlePreviousClick = () => emit("previous");
@@ -76,6 +81,12 @@ export default defineComponent({
       const startDate = getDayOnGMT(props.selectedWeek[0].date);
 
       return differenceInCalendarWeeks(startDate, today, {weekStartsOn: 1});
+    });
+
+    // TODO see if can be updated later. "ArrowLeft" binds to "a" key. Filled an issue with the plugin.
+    hotkeys('*', function(ev) {
+      if (ev.key === "ArrowRight" && weekDifference.value <= 3) handleNextClick();
+      if (ev.key === "ArrowLeft") handlePreviousClick();
     });
 
     return {

--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -57,8 +57,8 @@ export default defineComponent({
     },
   },
   beforeDestroy() {
-    // Somehow, correctly only unbinds specifically "*". If other components, in a shared scope, use it, it will unbind it. Does not unbind other keys.
-    hotkeys.unbind('*');
+    hotkeys.unbind('right');
+    hotkeys.unbind('left');
   },
   setup(props, {emit}) {
     const handlePreviousClick = () => emit("previous");
@@ -83,11 +83,10 @@ export default defineComponent({
       return differenceInCalendarWeeks(startDate, today, {weekStartsOn: 1});
     });
 
-    // TODO see if can be updated later. "ArrowLeft" binds to "a" key. Filled an issue with the plugin.
-    hotkeys('*', function(ev) {
-      if (ev.key === "ArrowRight" && weekDifference.value <= 3) handleNextClick();
-      if (ev.key === "ArrowLeft") handlePreviousClick();
+    hotkeys('right', () => {
+      if (weekDifference.value <= 3) handleNextClick();
     });
+    hotkeys('left', handlePreviousClick);
 
     return {
       handlePreviousClick,

--- a/components/records/select-project-dialog.vue
+++ b/components/records/select-project-dialog.vue
@@ -35,6 +35,7 @@ import {
   PropType,
   ref,
 } from "@nuxtjs/composition-api";
+import hotkeys from 'hotkeys-js';
 
 export default defineComponent({
   emits: ["project-selected"],
@@ -43,6 +44,9 @@ export default defineComponent({
       type: Array as PropType<Customer[]>,
       default: () => [],
     },
+  },
+  beforeDestroy() {
+    hotkeys.unbind("n");
   },
   setup(_, {emit, refs}) {
     const selectState = ref(null);
@@ -73,6 +77,11 @@ export default defineComponent({
       event.preventDefault();
       handleSubmit();
     };
+
+    hotkeys('n', () => {
+      // @ts-ignore (BFormGroup does not have proper typing)
+      refs.modal.show("modal-add-project");
+    });
 
     return {
       selectState,

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -41,8 +41,8 @@ export default defineComponent({
     },
   },
   beforeDestroy() {
-    // Somehow, correctly only unbinds specifically "*". If other components, in a shared scope, use it, it will unbind it. Does not unbind other keys.
-    hotkeys.unbind('*');
+    hotkeys.unbind('right');
+    hotkeys.unbind('left');
   },
   setup(props, {emit}) {
     const handlePreviousClick = () => emit("previous");
@@ -58,11 +58,10 @@ export default defineComponent({
       return differenceInCalendarMonths(props.selectedDate, today);
     });
 
-    // TODO see if can be updated later. "ArrowLeft" binds to "a" key. Filled an issue with the plugin.
-    hotkeys('*', function(ev) {
-      if (ev.key === "ArrowRight" && monthDifference.value < 0) handleNextClick();
-      if (ev.key === "ArrowLeft") handlePreviousClick();
+    hotkeys('right', () => {
+      if (monthDifference.value < 0) handleNextClick();
     });
+    hotkeys('left', handlePreviousClick);
 
     return {
       handlePreviousClick,

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -2,15 +2,19 @@
   <div class="navigation-buttons">
     <div class="navigation-buttons__container">
       <b-button
+        v-b-tooltip.hover
         class="navigation-buttons__button"
+        title="Or use keyboard left to go to previous month"
         @click="handlePreviousClick()"
       >
         <b-icon icon="arrow-left" />
       </b-button>
 
       <b-button
+        v-b-tooltip.hover
         class="navigation-buttons__button"
         :disabled="monthDifference === 0"
+        title="Or use keyboard left to go to next month"
         @click="handleNextClick()"
       >
         <b-icon icon="arrow-right" />

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -30,6 +30,7 @@
 <script lang="ts">
 import {computed, defineComponent} from "@nuxtjs/composition-api";
 import {differenceInCalendarMonths, format} from "date-fns";
+import hotkeys from 'hotkeys-js';
 
 export default defineComponent({
   emits: ["previous", "next", "current"],
@@ -38,6 +39,10 @@ export default defineComponent({
       type: Date,
       required: true,
     },
+  },
+  beforeDestroy() {
+    // Somehow, correctly only unbinds specifically "*". If other components, in a shared scope, use it, it will unbind it. Does not unbind other keys.
+    hotkeys.unbind('*');
   },
   setup(props, {emit}) {
     const handlePreviousClick = () => emit("previous");
@@ -51,6 +56,12 @@ export default defineComponent({
     const monthDifference = computed(() => {
       const today = new Date();
       return differenceInCalendarMonths(props.selectedDate, today);
+    });
+
+    // TODO see if can be updated later. "ArrowLeft" binds to "a" key. Filled an issue with the plugin.
+    hotkeys('*', function(ev) {
+      if (ev.key === "ArrowRight" && monthDifference.value < 0) handleNextClick();
+      if (ev.key === "ArrowLeft") handlePreviousClick();
     });
 
     return {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "core-js": "^3.6.5",
     "date-fns": "^2.16.1",
     "firebase": "^8.0.1",
+    "hotkeys-js": "^3.8.7",
     "js-cookie": "^2.2.1",
     "jwt-decode": "^3.1.2",
     "nuxt": "^2.14.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6732,6 +6732,11 @@ hosted-git-info@^3.0.6:
   dependencies:
     lru-cache "^6.0.0"
 
+hotkeys-js@^3.8.7:
+  version "3.8.7"
+  resolved "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.8.7.tgz"
+  integrity sha512-ckAx3EkUr5XjDwjEHDorHxRO2Kb7z6Z2Sxul4MbBkN8Nho7XDslQsgMJT+CiJ5Z4TgRxxvKHEpuLE3imzqy4Lg==
+
 hsl-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/hsl-regex/-/hsl-regex-1.0.0.tgz"


### PR DESCRIPTION
# Changes
Arrow key navigation for months and weeks
Open "add project modal" with "n"

## Related issues
https://github.com/FrontMen/fm-hours/issues/176

## Added
Added hotkeyJS


## How to test
1. Go to home
2. if no timesheet visible press "n" to bring up modal
3. press escape to close modal (this is built-in, not something we added, but part of acceptance criteria)
4. use arrows to navigate through weeks. Max next rule should apply (max 3 weeks in the future)

1. Go to monthly overview
2. navigate through the months 
3. Max next should apply (cannot see future months)
4. Same for reports page

