### PR TITLE
Feat/unrestrict month ahead

### DIFF
--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -91,9 +91,7 @@ export default defineComponent({
       return differenceInCalendarWeeks(startDate, today, {weekStartsOn: 1});
     });
 
-    hotkeys('right', () => {
-      handleNextClick();
-    });
+    hotkeys('right', handleNextClick);
     hotkeys('left', handlePreviousClick);
 
     return {

--- a/components/records/navigation-buttons.vue
+++ b/components/records/navigation-buttons.vue
@@ -35,7 +35,6 @@
 
         <b-button
           v-b-tooltip.hover
-          :disabled="weekDifference > 3"
           title="Or use keyboard right to go to next week"
           @click="handleNextClick()"
         >
@@ -93,7 +92,7 @@ export default defineComponent({
     });
 
     hotkeys('right', () => {
-      if (weekDifference.value <= 3) handleNextClick();
+      handleNextClick();
     });
     hotkeys('left', handlePreviousClick);
 

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -13,7 +13,6 @@
       <b-button
         v-b-tooltip.hover
         class="navigation-buttons__button"
-        :disabled="monthDifference === 0"
         title="Or use keyboard left to go to next month"
         @click="handleNextClick()"
       >
@@ -63,7 +62,7 @@ export default defineComponent({
     });
 
     hotkeys('right', () => {
-      if (monthDifference.value < 0) handleNextClick();
+      handleNextClick();
     });
     hotkeys('left', handlePreviousClick);
 

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -13,7 +13,7 @@
       <b-button
         v-b-tooltip.hover
         class="navigation-buttons__button"
-        title="Or use keyboard left to go to next month"
+        title="Or use keyboard right to go to next month"
         @click="handleNextClick()"
       >
         <b-icon icon="arrow-right" />

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -61,9 +61,7 @@ export default defineComponent({
       return differenceInCalendarMonths(props.selectedDate, today);
     });
 
-    hotkeys('right', () => {
-      handleNextClick();
-    });
+    hotkeys('right', handleNextClick);
     hotkeys('left', handlePreviousClick);
 
     return {

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -33,34 +33,84 @@
       @copy-previous-week="copyPreviousWeek"
     />
 
-    <template v-else>
+    <template>
       <form action="javascript:void(0);">
-        <weekly-timesheet :selected-week="recordsState.selectedWeek">
-          <template #rows>
-            <weekly-timesheet-row
-              v-for="(project, index) in timesheet.projects"
-              :key="`${project.customer.id}-${recordsState.selectedWeek[0].date}`"
-              :project="timesheet.projects[index]"
-              :readonly="!isAdminView && (isReadonly || project.isExternal)"
-              :removeable="!isAdminView && !isReadonly && !project.isExternal"
-              :selected-week="recordsState.selectedWeek"
-              :value-formatter="timesheetFormatter"
-              :employee="employee"
-              @save="saveTimesheet(recordStatus.NEW)"
-              @change="hasUnsavedChanges = true"
-              @remove="deleteProject(timesheet.projects[index])"
-            />
+        <template v-if="timesheet.projects.length">
+          <weekly-timesheet :selected-week="recordsState.selectedWeek">
+            <template #rows>
+              <weekly-timesheet-row
+                v-for="(project, index) in timesheet.projects"
+                :key="`${project.customer.id}-${recordsState.selectedWeek[0].date}`"
+                :project="timesheet.projects[index]"
+                :readonly="!isAdminView && (isReadonly || project.isExternal)"
+                :removeable="!isAdminView && !isReadonly && !project.isExternal"
+                :selected-week="recordsState.selectedWeek"
+                :value-formatter="timesheetFormatter"
+                :employee="employee"
+                @save="saveTimesheet(recordStatus.NEW)"
+                @change="hasUnsavedChanges = true"
+                @remove="deleteProject(timesheet.projects[index])"
+              />
 
-            <weekly-timesheet-totals-row
-              :projects="timesheet.projects"
+              <weekly-timesheet-totals-row
+                :projects="timesheet.projects"
+                :selected-week="recordsState.selectedWeek"
+                :work-scheme="recordsState.workScheme"
+                :show-add-project-button="
+                  !isReadonly && selectableCustomers.length > 0
+                "
+              />
+            </template>
+          </weekly-timesheet>
+
+          <template
+            v-if="employee && (employee.standBy || isAdminView) && timesheet.standByProject"
+          >
+            <weekly-timesheet
               :selected-week="recordsState.selectedWeek"
-              :work-scheme="recordsState.workScheme"
-              :show-add-project-button="
-                !isReadonly && selectableCustomers.length > 0
-              "
-            />
+              :active="!!employee.standBy"
+              :title="'Stand-by hours'"
+            >
+              <template #rows>
+                <weekly-timesheet-row
+                  :key="recordsState.selectedWeek[0].date"
+                  :project="timesheet.standByProject"
+                  :readonly="!isAdminView && isReadonly"
+                  :removable="false"
+                  :selected-week="recordsState.selectedWeek"
+                  :value-formatter="timesheetFormatter"
+                  :employee="employee"
+                  @change="hasUnsavedChanges = true"
+                  @remove="deleteProject(timesheet.projects[index])"
+                />
+              </template>
+            </weekly-timesheet>
           </template>
-        </weekly-timesheet>
+
+          <template
+            v-if="employee && (employee.travelAllowance || isAdminView) && timesheet.travelProject"
+          >
+            <weekly-timesheet
+              :selected-week="recordsState.selectedWeek"
+              :active="!!employee.travelAllowance"
+              :title="'Travel allowance'"
+            >
+              <template #rows>
+                <weekly-timesheet-row
+                  :key="recordsState.selectedWeek[0].date"
+                  :project="timesheet.travelProject"
+                  :readonly="!isAdminView && isReadonly"
+                  :removable="false"
+                  :selected-week="recordsState.selectedWeek"
+                  :value-formatter="kilometerFormatter"
+                  :employee="employee"
+                  @change="hasUnsavedChanges = true"
+                />
+              </template>
+            </weekly-timesheet>
+          </template>
+
+        </template>
 
         <template v-if="timesheet.leaveDays">
           <weekly-timesheet
@@ -82,55 +132,8 @@
           </weekly-timesheet>
         </template>
 
-        <template
-          v-if="employee && (employee.standBy || isAdminView) && timesheet.standByProject"
-        >
-          <weekly-timesheet
-            :selected-week="recordsState.selectedWeek"
-            :active="!!employee.standBy"
-            :title="'Stand-by hours'"
-          >
-            <template #rows>
-              <weekly-timesheet-row
-                :key="recordsState.selectedWeek[0].date"
-                :project="timesheet.standByProject"
-                :readonly="!isAdminView && isReadonly"
-                :removable="false"
-                :selected-week="recordsState.selectedWeek"
-                :value-formatter="timesheetFormatter"
-                :employee="employee"
-                @change="hasUnsavedChanges = true"
-                @remove="deleteProject(timesheet.projects[index])"
-              />
-            </template>
-          </weekly-timesheet>
-        </template>
-
-        <template
-          v-if="employee && (employee.travelAllowance || isAdminView) && timesheet.travelProject"
-        >
-          <weekly-timesheet
-            :selected-week="recordsState.selectedWeek"
-            :active="!!employee.travelAllowance"
-            :title="'Travel allowance'"
-          >
-            <template #rows>
-              <weekly-timesheet-row
-                :key="recordsState.selectedWeek[0].date"
-                :project="timesheet.travelProject"
-                :readonly="!isAdminView && isReadonly"
-                :removable="false"
-                :selected-week="recordsState.selectedWeek"
-                :value-formatter="kilometerFormatter"
-                :employee="employee"
-                @change="hasUnsavedChanges = true"
-              />
-            </template>
-          </weekly-timesheet>
-        </template>
-
         <b-form-textarea
-          v-if="!isReadonly || message"
+          v-if="(!isReadonly || message) && timesheet.projects.length "
           id="message-textarea"
           v-model="message"
           class="mt-4"


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/207

## Removed

Limit of month of looking ahead / add timesheets

## Bonus

Fixed a small issue where leave days wouldn't show if there is no projects present because of wrong if statement. 

## How to test

Go to home page and start going next weeks, after these changes it should go ahead unlimited
Go to monthly overview and start going next months, after these changes it should go ahead unlimited

## Screenshots



https://user-images.githubusercontent.com/7356299/127307080-22bdfa87-fcab-496f-8294-4284da1a7b50.mov




