### PR TITLE
fix: make sure csv only exports correct tables

### DIFF
--- a/components/reports/reports-table.vue
+++ b/components/reports/reports-table.vue
@@ -27,7 +27,7 @@ export default defineComponent({
   },
   setup(props) {
     const downloadCsv = (csv: any, filename: string) => {
-      const csvFile = new Blob([csv], {type: "text/csv"});
+      const csvFile = new Blob(["\uFEFF"+csv], {type: "text/csv; charset=utf-18"});
       const downloadLink = document.createElement("a");
 
       downloadLink.download = filename;

--- a/pages/reports.vue
+++ b/pages/reports.vue
@@ -9,7 +9,7 @@
     />
 
     <b-tabs pills card>
-      <b-tab title="Totals" active>
+      <b-tab title="Totals" active lazy>
         <reports-table
           :busy="isLoading || !totalsItems.length"
           :items="totalsItems"
@@ -18,7 +18,7 @@
         />
       </b-tab>
 
-      <b-tab title="Projects">
+      <b-tab title="Projects" lazy>
         <reports-table
           :busy="isLoading || !projectsItems.length"
           :items="projectsItems"
@@ -27,7 +27,7 @@
         />
       </b-tab>
 
-      <b-tab title="Kilometers">
+      <b-tab title="Kilometers" lazy>
         <reports-table
           :busy="isLoading || !kilometersItems.length"
           :items="kilometersItems"
@@ -36,7 +36,7 @@
         />
       </b-tab>
 
-      <b-tab title="Stand-by">
+      <b-tab title="Stand-by" lazy>
         <reports-table
           :busy="isLoading || !standByItems.length"
           :items="standByItems"


### PR DESCRIPTION
# Changes
adding "lazy" to a tab makes sure to mount and unmount inner components based on which tab is active.
This prevents retrieving all tables with querySelectorAll without needing ref or classes. 

## Related issues
closes https://github.com/FrontMen/fm-hours/issues/190

## Changed

Added lazy propriety on b-tab in reports

## How to test
1. Go to /reports
2.  Download csv on any of the tabs
3. The downloaded csv, with coresponding name based on tab, should only contain data visible in that tab

