### PR TITLE
fix: change layout of monthly nav to make it more predictable

### DIFF
--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -11,6 +11,15 @@
       </b-button>
 
       <b-button
+        v-b-tooltip
+        class="navigation-buttons__button"
+        title="To current month"
+        @click="handleCurrentClick"
+      >
+        <b-icon icon="calendar2-date" />
+      </b-button>
+
+      <b-button
         v-b-tooltip.hover
         class="navigation-buttons__button"
         title="Or use keyboard right to go to next month"
@@ -22,10 +31,6 @@
       <h2 class="navigation-buttons__week-label">
         {{ monthLabel }}
       </h2>
-      <b-button v-if="monthDifference !== 0" @click="handleCurrentClick">
-        <b-icon icon="calendar2-date" />
-        <span class="ml-2 d-none d-sm-inline">To current month</span>
-      </b-button>
     </div>
   </div>
 </template>
@@ -50,10 +55,12 @@ export default defineComponent({
   setup(props, {emit}) {
     const handlePreviousClick = () => emit("previous");
     const handleNextClick = () => emit("next");
-    const handleCurrentClick = () => emit("current");
+    const handleCurrentClick = () => {
+      if (monthDifference.value !== 0) emit("current");
+    }
 
     const monthLabel = computed(() => {
-      return format(props.selectedDate, "MMMM");
+      return format(props.selectedDate, "MMMM yyyy");
     });
 
     const monthDifference = computed(() => {

--- a/components/reports/month-navigation-buttons.vue
+++ b/components/reports/month-navigation-buttons.vue
@@ -11,7 +11,7 @@
       </b-button>
 
       <b-button
-        v-b-tooltip
+        v-b-tooltip.hover
         class="navigation-buttons__button"
         title="To current month"
         @click="handleCurrentClick"

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -109,7 +109,6 @@
               </template>
             </weekly-timesheet>
           </template>
-
         </template>
 
         <template v-if="timesheet.leaveDays">


### PR DESCRIPTION
# Changes
Changed layout of month nav.
Previously, based on month name, the button for current would jump around. Now button in center, always visible, and with handy tooltip to clarify what it does.
Also added year since we can move through the months indefinitely.

## Related issues
closes https://github.com/FrontMen/fm-hours/issues/184

## How to test
1. Go to /month or /reports 
2. Test month navigation
3. Note no weird button jumps as in the ticket

## Screenshots
![image](https://user-images.githubusercontent.com/85111889/127323385-074562bd-8ad1-4ef8-a015-0159fe6e0caf.png)
