### PR TITLE
Feat: message history

### DIFF
--- a/components/records/comment-block.vue
+++ b/components/records/comment-block.vue
@@ -1,0 +1,63 @@
+<template>
+  <div class="comment-block border rounded border-secondary mt-4">
+    <div v-if="!!formatedDate" class="comment-block__header">
+      {{`Sent at ${formatedDate}`}}
+    </div>
+    <p class="comment-block__text">
+      {{text}}
+    </p>
+  </div>
+</template>
+
+<script lang="ts">
+import {
+  defineComponent,
+  computed
+} from "@nuxtjs/composition-api";
+import {format} from "date-fns";
+
+export default defineComponent({
+  props: {
+    text: {
+      type: String,
+      required: true,
+    },
+    date: {
+      type: Number,
+      required: false
+    }
+  },
+  setup(props) {
+    const formatDate = (timestamp: number) => format(timestamp, "dd/MM/yyyy HH:mm");
+
+    const formatedDate = computed(() => props.date ? formatDate(props.date) : '')
+
+    return {
+      formatedDate
+    }
+  },
+})
+</script>
+
+<style lang="scss" scoped>
+.comment-block {
+ position: relative;
+ overflow: hidden;
+
+ &__header {
+   position: relative;
+   left: 0;
+   top: 0;
+   width: 100%;
+
+   font-size: 12px;
+   background-color: #bbb;
+
+   padding: 0.3rem 1rem;
+ }
+
+ &__text {
+   margin: 1rem;
+ }
+}
+</style>

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -70,27 +70,13 @@ export default (
     {immediate: true}
   );
 
-  const message = ref<string>(
-    timesheetState.value?.timesheets[0]
-      ? timesheetState.value?.timesheets[0].message
-      : ''
+  const message = ref<string | undefined>(
+    timesheetState.value?.timesheets[0]?.message
   );
   watch(
     () => timesheetState.value?.timesheets[0],
     () => {
       message.value = timesheetState.value?.timesheets[0]?.message;
-    },
-    {immediate: true}
-  );
-
-  /*
-   * Gets message from previous week's timesheet when copying.
-   */
-  watch(
-    () => store.state.timesheets.previousTimesheet,
-    () => {
-      message.value =
-        store.state.timesheets.previousTimesheet?.message || message.value;
     },
     {immediate: true}
   );
@@ -172,13 +158,6 @@ export default (
     );
     const prevStartDate = subDays(startDate, 7);
     const previousWeek = buildWeek(startOfISOWeek(prevStartDate));
-
-    // Dispatch getter to update message with message present in previous week.
-    store.dispatch('timesheets/getPreviousTimesheet', {
-      startDate: prevStartDate.getTime(),
-      endDate: startDate.getTime(),
-      employeeId,
-    });
 
     const previousWeekTimesheet = createWeeklyTimesheet({
       week: previousWeek,

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -10,7 +10,7 @@ import {
   createLeaveProject,
 } from '~/helpers/timesheet';
 import {buildEmailData} from '~/helpers/email';
-import {debounce} from '~/helpers/helpers';
+import {debounce, uuidv4} from '~/helpers/helpers';
 
 export default (
   employeeId: string,
@@ -23,6 +23,8 @@ export default (
   const recordsState = computed(() => store.state.records);
   const timesheetState = computed(() => store.state.timesheets);
   const customers = computed(() => store.state.customers);
+  const message = computed(() => timesheetState.value?.timesheets[0]?.message);
+  const messageInput = ref('');
 
   const timesheetStatus = computed(() => {
     return timesheetState.value.timesheets[0]
@@ -58,25 +60,12 @@ export default (
   });
 
   const messages = ref<Message[]>(
-    timesheetState.value?.timesheets[0]
-      ? timesheetState.value?.timesheets[0].messages
-      : []
+    timesheetState.value?.timesheets[0]?.messages || []
   );
   watch(
     () => timesheetState.value?.timesheets[0],
     () => {
-      messages.value = timesheetState.value?.timesheets[0]?.messages;
-    },
-    {immediate: true}
-  );
-
-  const message = ref<string | undefined>(
-    timesheetState.value?.timesheets[0]?.message
-  );
-  watch(
-    () => timesheetState.value?.timesheets[0],
-    () => {
-      message.value = timesheetState.value?.timesheets[0]?.message;
+      messages.value = timesheetState.value?.timesheets[0]?.messages || [];
     },
     {immediate: true}
   );
@@ -108,6 +97,7 @@ export default (
 
     unsavedWeeklyTimesheet.value = undefined;
     hasUnsavedChanges.value = false;
+    messageInput.value = '';
     store.dispatch('records/goToWeek', {bridgeUid, to});
   };
 
@@ -144,7 +134,7 @@ export default (
       store.dispatch('timesheets/deleteTimesheet', {
         timesheetId: timesheetState.value?.timesheets[0]?.id,
       });
-      message.value = '';
+      messageInput.value = '';
     }
 
     if (!unsavedWeeklyTimesheet.value?.projects.length) {
@@ -272,19 +262,31 @@ export default (
       reasonOfDenial = '';
     }
 
+    const createNewMessage = (text: string): Message => ({
+      id: uuidv4(),
+      createdAt: new Date().getTime(),
+      text,
+    });
+
+    const newMessages = messageInput.value
+      ? [...messages.value, createNewMessage(messageInput.value)]
+      : [...messages.value];
+
     const newTimesheet = timesheetState.value.timesheets[0]
       ? {
           ...timesheetState.value.timesheets[0],
           status: newTimesheetStatus,
           reasonOfDenial,
-          message: message.value || '',
+          messages: newMessages,
+          ...(message.value && {message: message.value}),
         }
       : {
           employeeId,
           date: new Date(recordsState.value.selectedWeek[0].date).getTime(),
           status: newTimesheetStatus,
           reasonOfDenial,
-          message: message.value || '',
+          messages: newMessages,
+          ...(message.value && {message: message.value}),
         };
 
     store.dispatch('timesheets/saveTimesheet', newTimesheet);
@@ -355,6 +357,7 @@ export default (
     timesheetDenyMessage,
     message,
     messages,
+    messageInput,
     denyTimesheet,
     autoSave: debouncedAutoSave,
   };

--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -57,6 +57,19 @@ export default (
     bridgeUid,
   });
 
+  const messages = ref<Message[]>(
+    timesheetState.value?.timesheets[0]
+      ? timesheetState.value?.timesheets[0].messages
+      : []
+  );
+  watch(
+    () => timesheetState.value?.timesheets[0],
+    () => {
+      messages.value = timesheetState.value?.timesheets[0]?.messages;
+    },
+    {immediate: true}
+  );
+
   const message = ref<string>(
     timesheetState.value?.timesheets[0]
       ? timesheetState.value?.timesheets[0].message
@@ -362,6 +375,7 @@ export default (
     isReadonly,
     timesheetDenyMessage,
     message,
+    messages,
     denyTimesheet,
     autoSave: debouncedAutoSave,
   };

--- a/helpers/helpers.ts
+++ b/helpers/helpers.ts
@@ -50,3 +50,9 @@ export const getTotalsByProp = <Type>(
     return (total += +currentValue);
   }, 0);
 };
+
+export function uuidv4() {
+  return '00-0-4-1-000'.replace(/[^-]/g, (s: any) =>
+    (((Math.random() + ~~s) * 0x10000) >> s).toString(16).padStart(4, '0')
+  );
+}

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -143,14 +143,13 @@
         </div>
 
         <b-form-textarea
-          v-if="(!isReadonly || message) && timesheet.projects.length "
+          v-if="!isReadonly && timesheet.projects.length"
           id="message-textarea"
-          v-model="message"
+          v-model="messageInput"
           class="mt-4"
           placeholder="Add a comment here."
           rows="1"
           max-rows="4"
-          :plaintext="!isAdminView && isReadonly"
           @change="hasUnsavedChanges = true"
           @blur="handleBlur"
         />

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -132,6 +132,16 @@
           </weekly-timesheet>
         </template>
 
+        <div v-if="message || messages" class="mt-4">
+          <comment-block v-if="!!message" :text="message" />
+          <comment-block
+            v-for="msg in messages"
+            :key="msg.id"
+            :text="msg.text"
+            :date="msg.createdAt"
+          />
+        </div>
+
         <b-form-textarea
           v-if="(!isReadonly || message) && timesheet.projects.length "
           id="message-textarea"
@@ -220,6 +230,7 @@ import SelectProjectDialog from "~/components/records/select-project-dialog.vue"
 import WeeklyTimesheetFooter from "~/components/records/weekly-timesheet-footer.vue";
 import WeeklyTimesheetRow from "~/components/records/weekly-timesheet-row.vue";
 import WeeklyTimesheetTotalsRow from "~/components/records/weekly-timesheet-totals-row.vue";
+import CommentBlock from "~/components/records/comment-block.vue";
 
 import useTimesheet from "~/composables/useTimesheet";
 import {recordStatus} from "~/helpers/record-status";
@@ -233,6 +244,7 @@ export default defineComponent({
     WeeklyTimesheetRow,
     WeeklyTimesheetFooter,
     WeeklyTimesheetTotalsRow,
+    CommentBlock
   },
   middleware: ["isAuthenticated"],
 

--- a/store/timesheets/actions.ts
+++ b/store/timesheets/actions.ts
@@ -19,22 +19,6 @@ const actions: ActionTree<TimesheetsStoreState, RootStoreState> = {
     commit('setTimesheets', {timesheets});
   },
 
-  /**
-   * Action similar to #getTimesheets, but expects to store 1 single timesheet to a different point in store.
-   * Used in copying previous week, to perpetuate the comment. Payload params mandatory for accuracy in search.
-   */
-  async getPreviousTimesheet(
-    {commit},
-    payload: {
-      startDate: number;
-      endDate: number;
-      employeeId: string;
-    }
-  ) {
-    const timesheets = await this.app.$timesheetsService.getTimesheets(payload);
-    commit('setPreviousTimesheet', {timesheet: timesheets[0]});
-  },
-
   async getTableData(
     {commit},
     payload: {

--- a/store/timesheets/mutations.ts
+++ b/store/timesheets/mutations.ts
@@ -13,10 +13,6 @@ const mutations: MutationTree<TimesheetsStoreState> = {
     state.timesheets = payload.timesheets;
   },
 
-  setPreviousTimesheet: (state, payload: {timesheet: Timesheet}) => {
-    state.previousTimesheet = payload.timesheet;
-  },
-
   setTimesheetsTableData: (state, payload: {tableData: TimesheetTableData}) => {
     state.timesheetTableData = payload.tableData;
   },

--- a/store/timesheets/state.ts
+++ b/store/timesheets/state.ts
@@ -3,5 +3,4 @@ export default (): TimesheetsStoreState => ({
   selectedEmployeeId: '',
   timesheets: [],
   timesheetTableData: {} as TimesheetTableData,
-  previousTimesheet: null,
 });

--- a/types/timesheets.d.ts
+++ b/types/timesheets.d.ts
@@ -27,7 +27,6 @@ interface TimesheetsStoreState {
   selectedEmployeeId: string;
   timesheets: Timesheet[];
   timesheetTableData: TimesheetTableData;
-  previousTimesheet: Timesheet | null;
 }
 
 interface Message {
@@ -42,8 +41,8 @@ interface Timesheet {
   employeeId: string;
   status: TimesheetStatus;
   reasonOfDenial: string;
-  message: string;
   messages: Message[];
+  message?: string /** Only present on old timesheets with single comment */;
 }
 
 interface WeekSpan {

--- a/types/timesheets.d.ts
+++ b/types/timesheets.d.ts
@@ -41,7 +41,7 @@ interface Timesheet {
   employeeId: string;
   status: TimesheetStatus;
   reasonOfDenial: string;
-  messages: Message[];
+  messages?: Message[];
   message?: string /** Only present on old timesheets with single comment */;
 }
 

--- a/types/timesheets.d.ts
+++ b/types/timesheets.d.ts
@@ -30,6 +30,12 @@ interface TimesheetsStoreState {
   previousTimesheet: Timesheet | null;
 }
 
+interface Message {
+  id: string;
+  text: string;
+  createdAt: number;
+}
+
 interface Timesheet {
   id: string;
   date: number;
@@ -37,6 +43,7 @@ interface Timesheet {
   status: TimesheetStatus;
   reasonOfDenial: string;
   message: string;
+  messages: Message[];
 }
 
 interface WeekSpan {


### PR DESCRIPTION
# Changes

## Related issues

Resolves #177 

## Added

- Comments now are a thread of messages

## Removed

- Copying comments when clicking in "copy previous week"

## Changed

- Previous message structure, as a single string, is still supported.
- New comments will be saved as an array of strings

## How to test

- Go to any timesheet
- Add a new comment
- Add another comment
- All comments should be displayed as a sequence of commentary blocks
- Copy previous week shouldn't copy the comments
- All other behaviours should stay as before

## Screenshots

<img width="1904" alt="Screenshot 2021-08-03 at 17 20 56" src="https://user-images.githubusercontent.com/45885054/128042706-a737ecdd-37ca-4ad1-abec-8c02d9cfc067.png">

