### PR TITLE
feat: records add notification when workscheme can't be fetched

### DIFF
--- a/components/records/weekly-timesheet-totals-row.vue
+++ b/components/records/weekly-timesheet-totals-row.vue
@@ -83,7 +83,7 @@ export default defineComponent({
 
     const dayWorkSchemeHoursTotal = computed(() =>
       props.selectedWeek.map((_, index) =>
-        props.workScheme?.[index] ? props.workScheme[index].workHours : "-")
+        props.workScheme?.[index] ? props.workScheme[index].workHours : "0")
     );
 
     watch(

--- a/pages/records.vue
+++ b/pages/records.vue
@@ -12,6 +12,10 @@
         </a>
       </strong>
     </b-alert>
+    <b-alert :show="showBridgeError" dismissible variant="warning" class="mb-3">
+      Could not get workschema data. Holidays, leave, or total hours will not be
+      shown correctly, but you can still fill in and submit your timesheet
+    </b-alert>
     <employee-header
       v-if="isAdminView && employee"
       class="mb-5"
@@ -300,6 +304,10 @@ export default defineComponent({
       timesheet.autoSave()
     };
 
+  const showBridgeError = computed(()=>{
+    return !!store.state.records.errorMessageWorkscheme;
+  })
+
     const selectableCustomers = computed(() => {
       const customers: Customer[] = store.state.customers.customers;
       const selectedCustomers = timesheet.timesheet.value.projects.map(
@@ -331,7 +339,7 @@ export default defineComponent({
     const submitTimesheet = () => {
       let confirmation = true;
 
-      if (totals.weekTotal > totals.expectedWeekTotal) {
+      if (totals.weekTotal > totals.expectedWeekTotal && !showBridgeError) {
         const difference = +(totals.weekTotal - totals.expectedWeekTotal).toFixed(2);
         confirmation = confirm(
           `You have filled in ${difference} more hour${difference !== 1 ? 's': ''} than the expected ${totals.expectedWeekTotal} hours a week. Is this correct?`
@@ -346,7 +354,7 @@ export default defineComponent({
           },
         );
 
-        if (daysExceedingExpected.length) confirmation = confirm(
+        if (daysExceedingExpected.length && !showBridgeError) confirmation = confirm(
           `You have filled in more hours than expected on some of the days. Is this correct?`
         );
       }
@@ -362,6 +370,7 @@ export default defineComponent({
       recordsState,
       recordStatus,
       isAdminView,
+      showBridgeError,
       reasonOfDenial,
       handleBlur,
       handleDeny,

--- a/services/work-scheme-service.ts
+++ b/services/work-scheme-service.ts
@@ -20,28 +20,23 @@ export default class WorkSchemeService {
   }): Promise<WorkScheme[] | undefined> {
     const {bridgeUid, startDate, endDate} = params;
 
-    try {
-      const response = await this.axios.$get<WorkSchemeResponse>(
-        `${ApiUrl(this.config)}/users/${bridgeUid}/worktime?date_from=${format(
-          startDate,
-          'yyyy-MM-dd'
-        )}&date_to=${format(endDate, 'yyyy-MM-dd')}`,
-        {
-          withCredentials: true,
-        }
-      );
+    const response = await this.axios.$get<WorkSchemeResponse>(
+      `${ApiUrl(this.config)}/users/${bridgeUid}/worktime?date_from=${format(
+        startDate,
+        'yyyy-MM-dd'
+      )}&date_to=${format(endDate, 'yyyy-MM-dd')}`,
+      {
+        withCredentials: true,
+      }
+    );
 
-      /* map API response to expected format */
-      return response.data.map((ws) => ({
-        date: ws.date,
-        theoreticalHours: ws.theoretical_hours,
-        absenceHours: ws.absence_hours,
-        workHours: ws.work_hours,
-        holiday: !!ws.holiday,
-      }));
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('API error', error);
-    }
+    /* map API response to expected format */
+    return response.data.map((ws) => ({
+      date: ws.date,
+      theoreticalHours: ws.theoretical_hours,
+      absenceHours: ws.absence_hours,
+      workHours: ws.work_hours,
+      holiday: !!ws.holiday,
+    }));
   }
 }

--- a/store/records/actions.ts
+++ b/store/records/actions.ts
@@ -45,12 +45,22 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
 
     const workWeek = buildWeek(startOfISOWeek(payload.startDate));
     let workSchemeResult: WorkScheme[] | undefined;
+
     if (payload.bridgeUid) {
-      workSchemeResult = await this.app.$workSchemeService.getWorkScheme({
-        bridgeUid: payload.bridgeUid,
-        startDate: new Date(workWeek[0].date),
-        endDate: new Date(workWeek[6].date),
-      });
+      try {
+        workSchemeResult = await this.app.$workSchemeService.getWorkScheme({
+          bridgeUid: payload.bridgeUid,
+          startDate: new Date(workWeek[0].date),
+          endDate: new Date(workWeek[6].date),
+        });
+      } catch (error) {
+        commit(
+          'setErrorMessageWorkscheme',
+          error.response
+            ? 'An unexpected error happened while trying to retrieve WorkScheme'
+            : error.message
+        );
+      }
     }
 
     const selectedWeek = checkNonWorkingDays(workWeek, workSchemeResult);

--- a/store/records/mutations.ts
+++ b/store/records/mutations.ts
@@ -52,6 +52,10 @@ const mutations: MutationTree<RecordsStoreState> = {
     state.selectedWeek = payload.selectedWeek;
     state.workScheme = payload.workScheme;
   },
+
+  setErrorMessageWorkscheme: (state, payload: string) => {
+    state.errorMessageWorkscheme = payload;
+  },
 };
 
 export default mutations;

--- a/store/records/state.ts
+++ b/store/records/state.ts
@@ -8,4 +8,6 @@ export default (): RecordsStoreState => ({
   leaveDays: [],
   standByRecords: [],
   workScheme: [],
+  errorMessage: '',
+  errorMessageWorkscheme: '',
 });

--- a/types/records.d.ts
+++ b/types/records.d.ts
@@ -57,6 +57,8 @@ interface RecordsStoreState {
   travelRecords: TravelRecord[];
   workScheme: WorkScheme[];
   standByRecords: StandbyRecord[];
+  errorMessage: string;
+  errorMessageWorkscheme: string;
 }
 
 interface RecordDayStatus {


### PR DESCRIPTION
# Changes

## Related issues

closes #220 

<!--- Add link to issue  -->

## Added

<!--- What is new on this code? -->

## Removed

<!--- What was removed? -->

## Changed

showing a notification when bridge API is down
replaces `-` with `0` in the totals row
removed validation when workscheme can't be fetched

## How to test
- In Chrome block the request to `http://localhost:3000/api/v1` 
- Go to records, a notifications should be shown.
- `-` should be replaced with `0`
- Submitting hours shouldn't trigger validation 
<!--- Add some steps or scenarios of how to test and validate these changes -->

## Screenshots
![image](https://user-images.githubusercontent.com/413695/128150620-b8485a8d-4b71-4719-92bb-ac9810124747.png)

<!--- In case of any visual changes, add some screenshots here -->
