### PR TITLE
fix(records): show 0 instead of NaN

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -155,8 +155,10 @@ export default defineComponent({
     watch(
       () => formattedProjectValues.value,
       () => {
-        const floatIntegers = formattedProjectValues.value.map(val =>
-          !isTravelAllowance ? timeStringToFloat(val) : +val,
+        const floatIntegers = formattedProjectValues.value.map(val => {
+          if (val === '') return 0
+          return !isTravelAllowance ? timeStringToFloat(val) : +val
+        }
         )
         props.project.values = floatIntegers
       },


### PR DESCRIPTION
# Changes

## Related issues

Resolves #221 

## Added

N/A

## Removed

N/A

## Changed

- The totals calculation now returns a `0` when there is no input.

## How to test

- When editing a timesheet, delete an input value.
- The total row should show a `0` as value inputed.

## Screenshots

N/A
