### PR TITLE
fix(timesheets): implement data checks for standby hours and travel kms

### DIFF
--- a/pages/records/index.vue
+++ b/pages/records/index.vue
@@ -69,7 +69,7 @@
           </weekly-timesheet>
 
           <template
-            v-if="employee && (employee.standBy || isAdminView) && timesheet.standByProject"
+            v-if="employee && employee.standBy && timesheet.standByProject && hasEmployeeStandby"
           >
             <weekly-timesheet
               :selected-week="recordsState.selectedWeek"
@@ -93,7 +93,7 @@
           </template>
 
           <template
-            v-if="employee && (employee.travelAllowance || isAdminView) && timesheet.travelProject"
+            v-if="employee && employee.travelAllowance && timesheet.travelProject && hasEmployeeTravelled"
           >
             <weekly-timesheet
               :selected-week="recordsState.selectedWeek"
@@ -304,6 +304,9 @@ export default defineComponent({
       selectedEmployee.value?.bridgeUid
     );
 
+    const hasEmployeeTravelled = computed(() => timesheet.timesheet.value.travelProject?.values.some((value: number) => value > 0));
+    const hasEmployeeStandby = computed(() => timesheet.timesheet.value.standByProject?.values.some((value: number) => value > 0));
+
     const reasonOfDenial = ref("");
 
     const handleDeny = () => {
@@ -394,6 +397,8 @@ export default defineComponent({
       isAdminView,
       showBridgeError,
       reasonOfDenial,
+      hasEmployeeTravelled,
+      hasEmployeeStandby,
       handleBlur,
       handleDeny,
       handleReminder,


### PR DESCRIPTION
# Changes
Added data checks on the templates to ensure we only display ones with values.

## Related issues

https://github.com/FrontMen/fm-hours/issues/222

## Added

- variable to check value for travel kms
- variable to check employee standby hours
- used variables in v-if on the standby and travel allowance components

## Removed

Check for isAdminView

