### PR TITLE
fix: rounding error

### DIFF
--- a/pages/month.vue
+++ b/pages/month.vue
@@ -188,7 +188,7 @@
         {{ formatDate(scope.item.date) }}
       </template>
       <template #cell(hours)="scope">
-        {{ parseFloat(scope.item.hours).toPrecision(3) }}
+        {{ parseFloat(scope.item.hours).toFixed(2) }}
       </template>
 
       <template #foot(hours)="">


### PR DESCRIPTION
# Changes

Fixed rounding issue on monthly overview

## Related issues

https://github.com/FrontMen/fm-hours/issues/234

## Added

`toFixed` function

## Removed

`toPrecision` function

## Changed

Replaced `toPrecision` function with the more correct `toFixed` function

## Screenshots

![image](https://user-images.githubusercontent.com/6754899/128849504-6bcc3b17-f86c-46c3-b45d-a0e9d6e293fe.png)

