### PR TITLE
fix: use european pattern for decimal numbers exported in the csv

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,4 @@ node_modules
 dist
 static
 .nuxt
+coverage

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+coverage

--- a/components/reports/reports-table.vue
+++ b/components/reports/reports-table.vue
@@ -33,6 +33,15 @@
 <script lang="ts">
 import {defineComponent} from "@vue/composition-api";
 
+function isNumeric(str: string) {
+  if (typeof str !== "string") return false;
+  return !isNaN(Number(str)) && !isNaN(parseFloat(str));
+}
+
+function convertDecimalToEuropeanStyle(numberText: string) {
+  return `"${numberText.replace(/\./g, ',')}"`;
+}
+
 export default defineComponent({
   props: {
     csvFileName: {type: String, default: "export"},
@@ -66,7 +75,7 @@ export default defineComponent({
             ""
           );
 
-          row.push(textContent);
+          row.push(isNumeric(textContent) ? convertDecimalToEuropeanStyle(textContent) : textContent);
         });
 
         csv.push(row.join(","));


### PR DESCRIPTION
# Changes

@matthiasdeboer was having problems importing exported CSV files into excel. Decimal values like 275.75 were showing as 27575 for him. This happens because his system configuration expected decimal values to be separated by a comma, instead of a dot. To fix this I converted strings that contain a decimal value to use comma separator.

## How to test

Export a CSV file containing decimal values from the report page and ask Matthias to try to import it into excel. (I did this already)

