### PR TITLE
fix: check unsaved changes before saving

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -236,6 +236,8 @@ export default (
     newTimesheetStatus: TimesheetStatus,
     denialMessage?: string
   ) => {
+    if (!hasUnsavedChanges.value) return;
+
     if (newTimesheetStatus === recordStatus.NEW && hasRestDayHours.value) {
       const confirmation = confirm(
         'You have add hours on weekends or holidays, are you sure you want to save this timesheet?'
@@ -329,9 +331,7 @@ export default (
   };
 
   const autoSave = () => {
-    if (hasUnsavedChanges.value) {
-      saveTimesheet(recordStatus.NEW as TimesheetStatus);
-    }
+    saveTimesheet(recordStatus.NEW as TimesheetStatus);
   };
 
   const debouncedAutoSave = debounce((cancel?: boolean) => {


### PR DESCRIPTION
# Changes

Check for unsaved changes before doing a timesheet save

## Related issues

https://github.com/FrontMen/fm-hours/issues/225

## Added

Added check for unsaved changes before running save logic

## Removed

Removed check around autosave code that was only being run during week changes

## Changed

Unsaved data checks

## How to test

- change data in the timesheet
- wait for autosave (5 seconds)
- change data in the timesheet again but then hit "Update" button
- wait to see if autosave triggers again (should not flash now - since autosave shouldn't trigger)
