### PR TITLE
fix: hide empty standby and travel allowances in admin view

### DIFF
--- a/pages/records/index.vue
+++ b/pages/records/index.vue
@@ -76,9 +76,7 @@
             </template>
           </weekly-timesheet>
 
-          <template
-            v-if="employee && employee.standBy && timesheet.standByProject"
-          >
+          <template v-if="showStandby">
             <weekly-timesheet
               :selected-week="recordsState.selectedWeek"
               :active="!!employee.standBy"
@@ -100,9 +98,7 @@
             </weekly-timesheet>
           </template>
 
-          <template
-            v-if="employee && employee.travelAllowance && timesheet.travelProject"
-          >
+          <template v-if="showTravel">
             <weekly-timesheet
               :selected-week="recordsState.selectedWeek"
               :active="!!employee.travelAllowance"
@@ -316,6 +312,22 @@ export default defineComponent({
       selectedEmployee.value?.bridgeUid
     );
 
+    const showTravel = computed(() => {
+      if (isAdminView) {
+        return timesheet.timesheet.value.travelProject?.values.some((value: number) => value > 0);
+      } else {
+        return (selectedEmployee && selectedEmployee.value?.travelAllowance && timesheet.timesheet.value.travelProject);
+      }
+    });
+
+    const showStandby = computed(() => {
+      if (isAdminView) {
+        return timesheet.timesheet.value.standByProject?.values.some((value: number) => value > 0);
+      } else {
+        return (selectedEmployee && selectedEmployee.value?.standBy && timesheet.timesheet.value.standByProject);
+      }
+    });
+
     const reasonOfDenial = ref("");
 
     const handleDeny = () => {
@@ -406,6 +418,8 @@ export default defineComponent({
       isAdminView,
       showBridgeError,
       reasonOfDenial,
+      showTravel,
+      showStandby,
       handleBlur,
       handleDeny,
       handleReminder,


### PR DESCRIPTION
# Changes

Hide empty travel allowances and standby hours in admin view

## Related issues

https://github.com/FrontMen/fm-hours/issues/253

## Added

Checks for admin view determining whether there are values tracked in the travel allowances and standby hours respectively

## Removed

old in line checks

## Changed

added computed variable checks to hide empty tables

## How to test

- in timesheets view, click a person's week who has travel/standby toggled on
- if there are no values tracked for travel/standby the tables should be hidden
- tables should be viewed only if they have values tracked.
- employees can track their hours/kms in the standard home page

