### PR TITLE
fix: add check for timesheet status in save

### DIFF
--- a/composables/useTimesheet.ts
+++ b/composables/useTimesheet.ts
@@ -236,7 +236,11 @@ export default (
     newTimesheetStatus: TimesheetStatus,
     denialMessage?: string
   ) => {
-    if (!hasUnsavedChanges.value) return;
+    if (
+      newTimesheetStatus === timesheetStatus.value &&
+      !hasUnsavedChanges.value
+    )
+      return;
 
     if (newTimesheetStatus === recordStatus.NEW && hasRestDayHours.value) {
       const confirmation = confirm(


### PR DESCRIPTION
# Changes

Improved save check to include the timesheet status

## Related issues

https://github.com/FrontMen/fm-hours/issues/262

## Added

Check for timesheet status

## Removed

n/a

## Changed

improved save check logic to include timesheet status which was preventing approval saves

## How to test

timesheets can be approved again

