### PR TITLE
feat: remove timesheet autosave

### DIFF
--- a/components/records/weekly-timesheet-footer.vue
+++ b/components/records/weekly-timesheet-footer.vue
@@ -4,11 +4,13 @@
     waiting: "Waiting on approval"
     denied: "Resubmit for approval"
     submit: "Submit for approval"
+    save: "Save"
   nl:
     unsubmit: "Terugtrekken"
     waiting: "Wacht op akkoord"
     denied: "Opnieuw insturen voor akkoord"
     submit: "Verzenden"
+    save: "Opslaan"
 </i18n>
 
 <template>
@@ -23,7 +25,7 @@
       :disabled="isSaving || !hasUnsavedChanges"
       @click="handleSaveClick"
     >
-      {{$t('update')}}
+      {{$t('save')}}
     </b-button>
 
     <b-button
@@ -56,7 +58,6 @@ import {formatDistanceToNow} from "date-fns";
 import {recordStatus} from "~/helpers/record-status";
 
 export default defineComponent({
-  emits: ["submit", "save", "unsubmit"],
   props: {
     hasUnsavedChanges: {
       type: Boolean,
@@ -69,12 +70,14 @@ export default defineComponent({
     lastSaved: {
       type: Date,
       required: false,
+      default: null,
     },
     status: {
       type: String as PropType<TimesheetStatus>,
       required: true,
     },
   },
+  emits: ["submit", "save", "unsubmit"],
   setup(props, {emit}) {
     const lastSavedLabel = ref("");
     let intervalHandle: NodeJS.Timeout;

--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -61,11 +61,10 @@
         class="weekly-timesheet-row__value-input"
         type="text"
         inputmode="decimal"
-        :formatter="valueFormatter.formatter"
+        :formatter="valueFormatter && valueFormatter.formatter"
         :readonly="isReadonlyList[index]"
         @focus.native="handleInputFocus($event.target, index)"
         @input="$emit('change')"
-        @blur="handleBlur"
       />
     </b-col>
     <b-col cols="1" class="weekly-timesheet-row__total-column">
@@ -89,10 +88,7 @@ import {
   floatToTotalTimeString,
   timeStringToFloat,
 } from '~/helpers/timesheet';
-import {debounce} from '~/helpers/helpers';
 import {recordDayStatusProps} from '~/helpers/record-status';
-
-let self: any;
 
 export default defineComponent({
   props: {
@@ -114,13 +110,14 @@ export default defineComponent({
     },
     valueFormatter: {
       type: Object as PropType<{min: number; max: number; formatter(): void}>,
+      default: null,
     },
     employee: {
       type: Object as PropType<Employee>,
       required: true,
     },
   },
-  emits: ['remove', 'save'],
+  emits: ['remove'],
   setup(props, {emit}) {
     const tooltip = ref();
     const canRemove = computed(() => !props.readonly && props.removable);
@@ -132,14 +129,6 @@ export default defineComponent({
     const handleRemoveClick = () => {
       closeTooltip();
       emit('remove', props.project);
-    };
-
-    function autoSave() {
-      emit('save');
-    }
-
-    const handleBlur = () => {
-      self.autoSave();
     };
 
     // Act as middleware to intercept project values to format it for the view
@@ -206,8 +195,6 @@ export default defineComponent({
     return {
       tooltip,
       canRemove,
-      autoSave,
-      handleBlur,
       closeTooltip,
       handleRemoveClick,
       totalValue,
@@ -216,10 +203,6 @@ export default defineComponent({
       handleInputFocus,
       shouldShowDarkBG,
     };
-  },
-  created() {
-    self = this;
-    self.autoSave = debounce(self.autoSave, 5000);
   },
 });
 </script>

--- a/pages/timesheets/_employee_id/_start_timestamp.vue
+++ b/pages/timesheets/_employee_id/_start_timestamp.vue
@@ -51,8 +51,6 @@
               :selected-week="recordsState.selectedWeek"
               :value-formatter="timesheetFormatter"
               :employee="employee"
-              @change="hasUnsavedChanges = true"
-              @remove="deleteProject(timesheet.projects[index])"
             />
 
             <weekly-timesheet-totals-row

--- a/pages/timesheets/_employee_id/_start_timestamp.vue
+++ b/pages/timesheets/_employee_id/_start_timestamp.vue
@@ -51,6 +51,8 @@
               :selected-week="recordsState.selectedWeek"
               :value-formatter="timesheetFormatter"
               :employee="employee"
+              @change="hasUnsavedChanges = true"
+              @remove="deleteProject(timesheet.projects[index])"
             />
 
             <weekly-timesheet-totals-row


### PR DESCRIPTION
# Changes
Removes autosave functionality on timesheets
Includes some refactors based on linting on touched components
## Related issues
https://github.com/FrontMen/fm-hours/issues/271

## Added

## Removed

## Changed

## How to test
1. Got ot timesheet
2. add a project
3. set an hour value and blur
4. wait few seconds - no autosave
5. save - save functionality works as expected
6. write a comment and blur
7. autosave not fired after a few seconds
8. save works as intended

Update button changed to "Save"

## Screenshots
![image](https://user-images.githubusercontent.com/85111889/134654805-c4198a4c-a539-477d-a3a3-fa67b94d2138.png)

