### PR TITLE
WIP feat: navigation based on startdate in url param for timesheets/ and …

### DIFF
--- a/store/records/actions.ts
+++ b/store/records/actions.ts
@@ -1,8 +1,8 @@
 /* eslint-disable camelcase */
-import {addDays, startOfISOWeek, subDays, isWithinInterval} from 'date-fns';
+import {startOfISOWeek, isWithinInterval} from 'date-fns';
 import {ActionTree} from 'vuex';
 
-import {buildWeek, checkNonWorkingDays, getDayOnGMT} from '~/helpers/dates';
+import {buildWeek, checkNonWorkingDays} from '~/helpers/dates';
 import {
   getTimeRecordsToSave,
   getTravelRecordsToSave,
@@ -99,19 +99,10 @@ const actions: ActionTree<RecordsStoreState, RootStoreState> = {
   },
 
   async goToWeek(
-    {commit, state},
-    payload: {to: 'current' | 'next' | 'previous'; bridgeUid?: string}
+    {commit},
+    payload: {startDate: Date; bridgeUid?: string}
   ) {
-    const currentStartDate = state.selectedWeek[0].date;
-    let newStartDate = new Date();
-
-    if (payload.to === 'previous') {
-      newStartDate = subDays(getDayOnGMT(currentStartDate), 7);
-    } else if (payload.to === 'next') {
-      newStartDate = addDays(getDayOnGMT(currentStartDate), 7);
-    }
-
-    const workWeek = buildWeek(startOfISOWeek(newStartDate));
+    const workWeek = buildWeek(startOfISOWeek(payload.startDate));
 
     let workSchemeResult: WorkScheme[] | undefined;
     if (payload.bridgeUid) {


### PR DESCRIPTION
Pushes startdate when navigating through timesheets, be it on home page, or /timesheets as admin. 
WIP - issue with comments not loading correctly (showing comments for previous week). Comments are not being correctly loaded anyway but further issues created by current PR, requiring further investigation.

# Changes

## Related issues

<!--- Add link to issue  -->

## Added

<!--- What is new on this code? -->

## Removed

<!--- What was removed? -->

## Changed

<!--- What has been changed? -->

## How to test

<!--- Add some steps or scenarios of how to test and validate these changes -->

## Screenshots

<!--- In case of any visual changes, add some screenshots here -->
