### PR TITLE
fix: remove unused messages object from timesheet

### DIFF
--- a/pages/timesheets/_employee_id/_start_timestamp.vue
+++ b/pages/timesheets/_employee_id/_start_timestamp.vue
@@ -389,14 +389,13 @@ export default defineComponent({
       } else if (newTimesheetStatus === recordStatus.PENDING) {
         reasonOfDenial = '';
       }
-      const newMessages = messageInput.value
+      // const newMessages = messageInput.value
 
       const newTimesheet = timesheetState.value.timesheets[0]
         ? {
             ...timesheetState.value.timesheets[0],
             status: newTimesheetStatus,
             reasonOfDenial,
-            messages: newMessages,
             ...(message.value && {message: message.value}),
           }
         : {
@@ -404,7 +403,6 @@ export default defineComponent({
             date: new Date(recordsState.value.selectedWeek[0].date).getTime(),
             status: newTimesheetStatus,
             reasonOfDenial,
-            messages: newMessages,
             ...(message.value && {message: message.value}),
           };
 


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/350


## Removed

Messages object from timesheet when saving. We will need to add this to its own submit/save function.

## How to test

Approve or unapprove a timesheet. 

