### PR TITLE
feat(error-message-no-employee): created middleware and components

### DIFF
--- a/.env.defaults
+++ b/.env.defaults
@@ -1,9 +1,0 @@
-FB_API_Key=FB_API_Key
-FB_AUTH_DOMAIN=fm-hours.firebaseapp.com
-FB_DATABASE_URL=https://fm-hours.firebaseio.com
-FB_PROJECT_ID=fm-hours
-FB_STORAGE_BUCKET=fm-hours.appspot.com
-FB_MESSAGING_SENDER_ID=FM_MESSAGING_SENDER
-FB_APP_ID=FB_APP_ID
-BRIDGE_URL=https://bridge.testing.intracto.com
-AUTH_URL=https://auth.hosted-tools.com

--- a/middleware/isEmployeeError.ts
+++ b/middleware/isEmployeeError.ts
@@ -1,0 +1,13 @@
+import {defineNuxtMiddleware} from '@nuxtjs/composition-api';
+
+export default defineNuxtMiddleware(({store, redirect, route}) => {
+  const employeeErrorRoutePath = '/error/employee';
+  const employeeError = store.getters['employee/error'];
+  const isCurrentPathEmployeeError = route.path === employeeErrorRoutePath;
+
+  if (!isCurrentPathEmployeeError && employeeError) {
+    return redirect(employeeErrorRoutePath);
+  } else if (isCurrentPathEmployeeError && !employeeError) {
+    return redirect('/');
+  }
+});

--- a/pages/_year/_week.vue
+++ b/pages/_year/_week.vue
@@ -14,6 +14,8 @@ import {computed, defineComponent, useContext, useMeta, useRouter, useStore, wat
 import {format} from "date-fns";
 
 export default defineComponent({
+  middleware: ["isEmployeeError"],
+
   setup() {
     const {i18n} = useContext();
     const router = useRouter();

--- a/pages/admin/employees/_id.vue
+++ b/pages/admin/employees/_id.vue
@@ -12,6 +12,7 @@ export default defineComponent({
     const router = useRouter();
 
     const employeeId = router.currentRoute.params.id;
+
     const employee = useAsync(() => app.$employeesService.getEmployee(employeeId));
     const employeeFormMode = 'edit';
 

--- a/pages/error/employee/index.vue
+++ b/pages/error/employee/index.vue
@@ -1,0 +1,51 @@
+<i18n lang="yaml">
+en:
+  error: {
+    employee: {
+      notFound:  "You haven't been added to the app yet. <br />
+                  Reach out to your manager to get access. <br />
+                  Afterwards refresh the page and start writing hours!"
+    }
+  }
+
+nl:
+  error: {
+      employee: {
+        notFound: "Je bent nog niet toegevoegd aan de app. <br />
+                   Neem contact op met je manager voor toegang. <br />
+                   Hierna kun je de pagina verversen en beginnen met uren schrijven!"
+      }
+    }
+ 
+</i18n>
+
+<template>
+  <b-alert variant="danger" show>
+    <center>
+      <p v-if="isEmployeeNotFound" v-html="$t('error.employee.notFound')"></p>
+      <p v-else>{{employeeError}}</p>
+    </center>
+  </b-alert>
+</template>
+
+<script lang="ts">
+import {defineComponent, useStore} from "@nuxtjs/composition-api";
+import {Errors} from '~/types/enums';
+
+
+export default defineComponent({
+  middleware: ["isEmployeeError"],
+  setup() {
+    const getters = useStore().getters;
+    const employeeError = getters["employee/error"];
+    const isEmployeeNotFound = employeeError.message === Errors.EMPLOYEE_NOT_FOUND;
+
+    return {
+      isEmployeeNotFound,
+      employeeError
+    };
+
+  }
+
+});
+</script>

--- a/pages/login.vue
+++ b/pages/login.vue
@@ -34,6 +34,7 @@ import {computed, defineComponent, useContext, useRouter, useStore,} from '@nuxt
 
 export default defineComponent({
   layout: 'login',
+  middleware: ['isNotAuthenticated'],
   setup() {
     const store = useStore<RootStoreState>();
     const router = useRouter();

--- a/pages/month.vue
+++ b/pages/month.vue
@@ -212,7 +212,7 @@ import {addMonths, endOfMonth, format, startOfMonth, subMonths} from 'date-fns';
 import {getTotalsByProp} from '~/helpers/helpers';
 
 export default defineComponent({
-
+  middleware: ['isEmployeeError'],
   setup() {
 
     const {i18n} = useContext();

--- a/store/auth/actions.ts
+++ b/store/auth/actions.ts
@@ -48,7 +48,6 @@ const actions: ActionTree<AuthStoreState, RootStoreState> = {
         this.$router.push(this.localePath('/login'));
       }
     }
-
     await dispatch('employee/getEmployee', {}, {root: true});
   },
 };

--- a/store/employee/actions.ts
+++ b/store/employee/actions.ts
@@ -4,6 +4,8 @@ import EmployeesService from '~/services/employees-service';
 import {generateAvatarURL} from '~/helpers/employee';
 import BridgeService from '~/services/bridge-service';
 
+import {Errors} from '~/types/enums';
+
 const actions: ActionTree<EmployeeStoreState, RootStoreState> = {
   async getEmployee({commit, rootState}) {
     if (!rootState.auth.user) return;
@@ -15,7 +17,7 @@ const actions: ActionTree<EmployeeStoreState, RootStoreState> = {
       const employee = await employeesService.getEmployeeByMail(user.email);
       const isAdmin = await employeesService.isAdmin(user.email);
 
-      if (!employee) throw new Error('Employee not found!');
+      if (!employee) throw new Error(Errors.EMPLOYEE_NOT_FOUND);
 
       // Retrieve BridgeUid if we haven't done this before
       if (!employee.bridgeUid) {
@@ -32,10 +34,11 @@ const actions: ActionTree<EmployeeStoreState, RootStoreState> = {
       }
 
       commit('setEmployee', {employee, isAdmin});
+      commit('setError', null);
 
       return employee;
-    } catch (error) {
-      throw new Error(error);
+    } catch (error: any) {
+      commit('setError', error);
     }
   },
 };

--- a/store/employee/getters.ts
+++ b/store/employee/getters.ts
@@ -1,0 +1,9 @@
+import {GetterTree} from 'vuex';
+
+const getters: GetterTree<EmployeeStoreState, RootStoreState> = {
+  error(state) {
+    return state.error;
+  },
+};
+
+export default getters;

--- a/store/employee/mutations.ts
+++ b/store/employee/mutations.ts
@@ -5,6 +5,9 @@ const mutations: MutationTree<EmployeeStoreState> = {
     state.employee = payload.employee;
     state.isAdmin = payload.isAdmin;
   },
+  setError: (state, payload) => {
+    state.error = payload;
+  },
 };
 
 export default mutations;

--- a/store/employee/state.ts
+++ b/store/employee/state.ts
@@ -1,4 +1,5 @@
 export default (): EmployeeStoreState => ({
   employee: null,
   isAdmin: false,
+  error: null,
 });

--- a/types/employee.d.ts
+++ b/types/employee.d.ts
@@ -27,4 +27,5 @@ interface Employee {
 interface EmployeeStoreState {
   employee: Employee | null;
   isAdmin: boolean;
+  error: Error | null;
 }

--- a/types/enums.ts
+++ b/types/enums.ts
@@ -17,3 +17,7 @@ export enum Collections {
   TIMESHEETS = 'timesheets',
   TRAVELREC = 'travel_records',
 }
+
+export enum Errors {
+  EMPLOYEE_NOT_FOUND = 'employee_not_found',
+}


### PR DESCRIPTION
# Changes

## Related issues

[<!--- Add link to issue  -->](https://github.com/FrontMen/fm-hours/issues/557)

## Added

- Middleware for handling errors across the app when there is no employee.
- Types for errors 
- New page /error/employee

## How to test

If you already have a user in the app then you'd need to change the email address associated to your user. Once changed try to login the application and you should see the error message that you have to request from an admin to add you to the system.

You can also test that the flow works correctly by changing your email address back to the correct one and then reload the page, you should then see your hours table.

## Screenshots

EN:
![image](https://user-images.githubusercontent.com/46437510/167848781-c5fc9725-ec0c-4a2a-b171-a93b4566df1a.png)

NL:
![image](https://user-images.githubusercontent.com/46437510/167848810-e95b0c66-56b2-475b-9348-bd1af189cc94.png)

