### PR TITLE
[WIP] feat(legenda to timesheets): added popover with all info

### DIFF
--- a/pages/admin/timesheets.vue
+++ b/pages/admin/timesheets.vue
@@ -22,9 +22,40 @@ nl:
             <b-icon icon="envelope" />
           </b-button>
 
-          <b-form-checkbox v-model="hideDone" name="checkbox-hide-done" inline>
-            {{ $t('hideDone') }}
-          </b-form-checkbox>
+          <div class="d-flex align-items-center mt-2">
+            <b-form-checkbox v-model="hideDone" name="checkbox-hide-done" inline>
+              {{ $t('hideDone') }}
+            </b-form-checkbox>
+
+            <!-- TODO: Translation -->
+            <b-button id="legend" variant="link" class="legend-button">
+              <b-icon icon="question-circle" />
+            </b-button>
+            <b-popover target="legend" triggers="hover" placement="right" class="d-block">
+              <div class="d-flex flex-column">
+                <div class="d-flex flex-row align-items-start justify-content-start">
+                  <div class="m-1 legend--cell"></div>
+                  <p class="mb-0">Empty</p>
+                </div>
+                <div class="d-flex flex-row align-items-start justify-content-start">
+                  <div class="m-1 legend--cell new"></div>
+                  <p class="mb-0">New</p>
+                </div>
+                <div class="d-flex align-items-center justify-content-start">
+                  <div class="m-1 legend--cell pending"></div>
+                  <p class="mb-0">Pending</p>
+                </div>
+                <div class="d-flex align-items-center justify-content-start">
+                  <div class="m-1 legend--cell approved"></div>
+                  <p class="mb-0">Approved</p>
+                </div>
+                <div class="d-flex align-items-center justify-content-start">
+                  <div class="m-1 legend--cell denied"></div>
+                  <p class="mb-0">Denied</p>
+                </div>
+              </div>
+            </b-popover>
+          </div>
         </div>
 
         <b-table
@@ -156,7 +187,15 @@ export default defineComponent({
   }
 }
 
-.container--cell {
+.legend-button {
+  box-shadow: none !important;
+  &:focus {
+    outline: none;
+    box-shadow: none;
+  }
+}
+
+.container--cell, .legend--cell {
   display: block;
   margin: auto;
   height: 16px;

--- a/pages/admin/timesheets.vue
+++ b/pages/admin/timesheets.vue
@@ -4,11 +4,23 @@ en:
   confirmReminder: 'Are you sure you want to remind {people}?'
   hideDone: "Hide done"
   emptyTable: "No employees to show"
+  legend: 
+    empty: Empty
+    new: New
+    pending: Pending
+    approved: Approved
+    denied: Denied
 nl:
   emailReminder: "Verstuur een e-mail herinnering naar iedereen met missende timesheets deze maand"
   confirmReminder: 'Are you sure you want to remind {people}?'
   hideDone: "Verberg klaar"
   emptyTable: "Geen medewerkers om te tonen"
+  legend: 
+    empty: Leeg
+    new: Nieuwe
+    pending: In afwachting
+    approved: Akkoordeer
+    denied: Niet toegestaan
 </i18n>
 
 <template>
@@ -27,7 +39,6 @@ nl:
               {{ $t('hideDone') }}
             </b-form-checkbox>
 
-            <!-- TODO: Translation -->
             <b-button id="legend" variant="link" class="legend-button">
               <b-icon icon="question-circle" />
             </b-button>
@@ -35,23 +46,23 @@ nl:
               <div class="d-flex flex-column">
                 <div class="d-flex flex-row align-items-start justify-content-start">
                   <div class="m-1 legend--cell"></div>
-                  <p class="mb-0">Empty</p>
+                  <p class="mb-0">{{ $t('legend.empty') }}</p>
                 </div>
                 <div class="d-flex flex-row align-items-start justify-content-start">
                   <div class="m-1 legend--cell new"></div>
-                  <p class="mb-0">New</p>
+                  <p class="mb-0">{{ $t('legend.new') }}</p>
                 </div>
                 <div class="d-flex align-items-center justify-content-start">
                   <div class="m-1 legend--cell pending"></div>
-                  <p class="mb-0">Pending</p>
+                  <p class="mb-0">{{ $t('legend.pending') }}</p>
                 </div>
                 <div class="d-flex align-items-center justify-content-start">
                   <div class="m-1 legend--cell approved"></div>
-                  <p class="mb-0">Approved</p>
+                  <p class="mb-0">{{ $t('legend.approved') }}</p>
                 </div>
                 <div class="d-flex align-items-center justify-content-start">
                   <div class="m-1 legend--cell denied"></div>
-                  <p class="mb-0">Denied</p>
+                  <p class="mb-0">{{ $t('legend.denied') }}</p>
                 </div>
               </div>
             </b-popover>
@@ -91,7 +102,7 @@ nl:
           <template #cell()="scope">
             <nuxt-link
               :class="['container--cell', scope.item[scope.field.key]]"
-              :title="$t(scope.item[scope.field.key])"
+              :title="$t(`legend.${scope.item[scope.field.key]}`)"
               :to="`/admin/timesheets/${scope.item.id}/${scope.field.year}/${scope.field.weekNumber}`"
             />
           </template>


### PR DESCRIPTION
# Changes

## Related issues

[Ticket](https://github.com/FrontMen/fm-hours/issues/246)

## Added

The bootstrap `b-popover` has been added to `timesheets.vue`. EG and NL translations are implemented as well.

## How to test

1. Go to /admin/timesheets page.
2. Next to 'Hide done' checkbox, you can find the [?] sign.
3. Hover on it and see all statuses that you can have.

## Screenshots

![Screenshot 2022-05-25 at 13 36 14](https://user-images.githubusercontent.com/41569040/170253411-6778043d-bc8b-47c0-8008-bbedcd00cf3c.png)

