### PR TITLE
[WIP] feat(move-from-firebase-to-vercel)

### DIFF
--- a/api/mail/send.ts
+++ b/api/mail/send.ts
@@ -1,0 +1,73 @@
+import {VercelRequest, VercelResponse} from '@vercel/node';
+import {createTransport, SendMailOptions, TransportOptions} from 'nodemailer';
+import {google} from 'googleapis';
+const OAuth2 = google.auth.OAuth2;
+
+export default function SendMail(request: VercelRequest, response: VercelResponse) {
+  try {
+    const createTransporter = async () => {
+        const oauth2Client = new OAuth2(
+        //   functions.config().mail.clientid,
+        //   functions.config().mail.clientsecret,
+          'https://developers.google.com/oauthplayground'
+        );
+  
+        oauth2Client.setCredentials({
+        //   refresh_token: functions.config().mail.refreshtoken,
+        });
+  
+        const accessToken = await new Promise((resolve, reject) => {
+          oauth2Client.getAccessToken((error: any, token: any) => {
+            if (error) {
+              reject(new Error('Failed to create access token'));
+            }
+            resolve(token);
+          });
+        });
+  
+        return createTransport({
+          service: 'gmail',
+          auth: {
+            type: 'OAuth2',
+            // user: functions.config().mail.user,
+            accessToken,
+            // clientId: functions.config().mail.clientid,
+            // clientSecret: functions.config().mail.clientsecret,
+            // refreshToken: functions.config().mail.refreshtoken,
+          },
+        } as TransportOptions);
+      };
+  
+      const {to, subject, html} = request.body;
+  
+      const mailOptions = {
+        // from: `Uren <${functions.config().mail.user}>"`,
+        to,
+        subject,
+        html,
+      } as SendMailOptions;
+  
+      const sendEmail = async (emailOptions: SendMailOptions) => {
+        const emailTransporter = await createTransporter();
+  
+        return emailTransporter.sendMail(emailOptions, (error: any) => {
+          if (error) {
+            // functions.logger.log('error', error);
+            return response.status(500).send(error.toString());
+          }
+          return response.send('E-mail sent successfully!');
+        });
+      };
+  
+      try {
+        return sendEmail(mailOptions);
+      } catch (error: any) {
+        // functions.logger.log('error', err);
+        return response.status(500).send(error.toString());
+      }
+  } catch (error: any) {
+    return response.status(401).json({
+      message: error.message,
+    });
+  }
+}

--- a/pages/admin/timesheets.vue
+++ b/pages/admin/timesheets.vue
@@ -110,6 +110,7 @@ import {
   useStore,
   watch,
 } from '@nuxtjs/composition-api';
+import axios from "axios";
 import {endOfMonth, getDay, setDay, startOfMonth} from 'date-fns';
 import {TimesheetStatus} from '~/types/enums';
 import {createReminderEmail} from '~/helpers/email';
@@ -228,18 +229,27 @@ export default defineComponent({
 
     const sendReminders = () => {
       const names = employeesWithMissingTimesheets.value.map(e => e.name).sort();
-      const confirmed = confirm(`Sending reminder to:\n${names.join(', \n')}`);
+      const mock = employeesWithMissingTimesheets.value.filter(({ name }) => name === 'Vlad Kostiuk');
+      console.log(mock);
+      // const confirmed = confirm(`Sending reminder to:\n${names.join(', \n')}`);
+      const confirmed = confirm(`Sending reminder to:`);
+
 
       if (confirmed) {
-        employeesWithMissingTimesheets.value.forEach(employee => {
-          const emailData = createReminderEmail({
-            employee,
-            startDate: startDate.value.getTime(),
-          });
+        mock.forEach(async (employee) => {
+          // const emailData = createReminderEmail({
+          //   employee,
+          //   startDate: startDate.value.getTime(),
+          // });
 
-          app.$mailService.sendMail(emailData);
-        });
-      }
+          //  app.$mailService.sendMail(emailData);
+
+          const path = `/api/mail/send/`;
+          const {data} = await axios.get(path);
+
+          console.log(data);
+         });
+       }
     };
 
     watch(

--- a/pages/admin/timesheets.vue
+++ b/pages/admin/timesheets.vue
@@ -229,14 +229,10 @@ export default defineComponent({
 
     const sendReminders = () => {
       const names = employeesWithMissingTimesheets.value.map(e => e.name).sort();
-      const mock = employeesWithMissingTimesheets.value.filter(({ name }) => name === 'Vlad Kostiuk');
-      console.log(mock);
-      // const confirmed = confirm(`Sending reminder to:\n${names.join(', \n')}`);
-      const confirmed = confirm(`Sending reminder to:`);
-
+      const confirmed = confirm(`Sending reminder to:\n${names.join(', \n')}`);
 
       if (confirmed) {
-        mock.forEach(async (employee) => {
+        employeesWithMissingTimesheets.value.forEach(async () => {
           // const emailData = createReminderEmail({
           //   employee,
           //   startDate: startDate.value.getTime(),


### PR DESCRIPTION
# Changes

## Related issues

Awesome [Ticket](https://github.com/FrontMen/fm-hours/issues/299) 🚀

## Added

1. Created `SendMail` function in the `api/mail/send.ts`. 
2. All old logic from `functions/src/sendMail.ts` moved there.

## TODO:

1. The old implementation should be removed - `functions/src/sendMail.ts`. (I left it as a reference).
2. At the moment we use `functions.config()` for configuration parameters as `clientid`, `clientsecret`, `refreshtoken`, `user`. All of these parameters be moved either to vercel evn or `.ENV` file.
3. Use `$mailService.sendMail()` instead of pure `axios.get` in `timesheets.vue`.

## How to test

1. If you don't want to bombard your colleagues with annoying emails, please, disable the sending of emails to all users in a `pages/admin/timesheets.vue` - see the `sendReminders` method. Use only your user as a recipient.
4. Go to `/admin/timesheets/` page.
5. Press the button with an envelope icon.
6. Go to your outlook and see what you got.
