### PR TITLE
chore: stop sending non-get api requests to bridge production from development

### DIFF
--- a/api/bridge/contracts/index.ts
+++ b/api/bridge/contracts/index.ts
@@ -1,5 +1,5 @@
 import {VercelRequest, VercelResponse} from '@vercel/node';
-import axios from 'axios';
+import axios from '../../../lib/axios';
 
 export default function Contracts(request: VercelRequest, response: VercelResponse) {
   const {contractId, jiraId, projectId, projectJiraId, projectKey, search} = request.query;

--- a/api/bridge/me.ts
+++ b/api/bridge/me.ts
@@ -1,5 +1,5 @@
 import {VercelRequest, VercelResponse} from '@vercel/node';
-import axios from 'axios';
+import axios from '../../lib/axios';
 
 export default async function UserMe(request: VercelRequest, response: VercelResponse) {
   try {

--- a/api/bridge/worklogs/[worklogId].ts
+++ b/api/bridge/worklogs/[worklogId].ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import {VercelRequest, VercelResponse} from '@vercel/node';
-import axios from 'axios';
 import {format} from 'date-fns';
+import axios from '../../../lib/axios';
 import {handleAxiosError} from '../../../lib/errors';
 
 export default async function Worklogs(request: VercelRequest, response: VercelResponse) {

--- a/api/bridge/worklogs/index.ts
+++ b/api/bridge/worklogs/index.ts
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 import {VercelRequest, VercelResponse} from '@vercel/node';
 import {format} from 'date-fns';
-import axios from 'axios';
+import axios from '../../../lib/axios';
 import {handleAxiosError} from '../../../lib/errors';
 
 export default async function Worklogs(request: VercelRequest, response: VercelResponse) {

--- a/api/bridge/workscheme/[bridgeUid].ts
+++ b/api/bridge/workscheme/[bridgeUid].ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import {VercelRequest, VercelResponse} from '@vercel/node';
-import axios from 'axios';
+import axios from '../../../lib/axios';
 import {validateParams} from '../../../lib/request';
 import {handleAxiosError, handleValidationError} from '../../../lib/errors';
 

--- a/components/employees/employee-form.vue
+++ b/components/employees/employee-form.vue
@@ -104,7 +104,7 @@ export default defineComponent({
     const router = useRouter();
     const store = useStore<RootStoreState>();
 
-    const projects = ref<EmployeeProject[]>(props.employee?.projects);
+    const projects = computed(() => props.employee?.projects)
     const selectedTeamId = ref<string>();
     const selectedProjects = ref<(Project[] | undefined)>([]);
     const hasUnsavedChanges = ref<boolean>(false);

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -1,0 +1,26 @@
+import axios from 'axios';
+
+const instance = axios.create();
+
+instance.interceptors.request.use(
+  requestConfig => {
+    if (axios.getUri(requestConfig).includes(process.env.BRIDGE_URL as string)) {
+      // Cancel bridge axios requests unless...
+      if (process.env.NODE_ENV !== 'development') return requestConfig;
+      if (requestConfig.method === 'get' || requestConfig.method === 'GET') return requestConfig;
+      if (axios.getUri(requestConfig).includes(process.env.AUTH_URL as string))
+        return requestConfig;
+
+      throw new axios.Cancel(
+        `Not sending '${requestConfig.method}' requests to Bridge production during development.`
+      );
+    }
+
+    return requestConfig;
+  },
+  error => {
+    return Promise.reject(error);
+  }
+);
+
+export default instance;

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -10,7 +10,7 @@ instance.interceptors.request.use(
     const isBridgeUrl = uri.includes(process.env.BRIDGE_URL as string);
     const isAuthUrl = uri.includes(process.env.AUTH_URL as string);
 
-    if (isDev && isGet && isBridgeUrl && !isAuthUrl) {
+    if (isDev && !isGet && isBridgeUrl && !isAuthUrl) {
       throw new axios.Cancel(
         `Not sending '${requestConfig.method}' requests to Bridge production during development.`
       );

--- a/lib/axios.ts
+++ b/lib/axios.ts
@@ -4,13 +4,13 @@ const instance = axios.create();
 
 instance.interceptors.request.use(
   requestConfig => {
-    if (axios.getUri(requestConfig).includes(process.env.BRIDGE_URL as string)) {
-      // Cancel bridge axios requests unless...
-      if (process.env.NODE_ENV !== 'development') return requestConfig;
-      if (requestConfig.method === 'get' || requestConfig.method === 'GET') return requestConfig;
-      if (axios.getUri(requestConfig).includes(process.env.AUTH_URL as string))
-        return requestConfig;
+    const uri = axios.getUri(requestConfig);
+    const isDev = process.env.NODE_ENV === 'development';
+    const isGet = requestConfig.method?.toLowerCase() === 'get';
+    const isBridgeUrl = uri.includes(process.env.BRIDGE_URL as string);
+    const isAuthUrl = uri.includes(process.env.AUTH_URL as string);
 
+    if (isDev && isGet && isBridgeUrl && !isAuthUrl) {
       throw new axios.Cancel(
         `Not sending '${requestConfig.method}' requests to Bridge production during development.`
       );

--- a/lib/intracto.ts
+++ b/lib/intracto.ts
@@ -1,5 +1,6 @@
 import jwtDecode from 'jwt-decode';
-import axios, {AxiosError} from 'axios';
+import {AxiosError} from 'axios';
+import axios from './axios';
 
 interface IDecodedToken {
   firebase: {


### PR DESCRIPTION
In order to prevent the sending of POST, PUT, UPDATE and DELETE to the IO bridge PROD api during development, I instantiated an Axios client used in the `/api` layer, to which I added a request interceptor.