### PR TITLE
feat: indicate the Bridge sync state in insights view

### DIFF
--- a/components/records/weekly-timesheet-row.vue
+++ b/components/records/weekly-timesheet-row.vue
@@ -28,7 +28,7 @@
         class="weekly-timesheet-row__value-icon"
       >
         <span v-b-tooltip.hover :title="timesheetProject?.worklogs?.[index]?.toString()">
-          <b-icon icon="cloud-arrow-up" />
+          <b-icon icon="cloud-check" />
         </span>
       </div>
     </b-col>

--- a/components/reports/date-reports.vue
+++ b/components/reports/date-reports.vue
@@ -159,9 +159,6 @@ nl:
         <span v-if="scope.item.worklogId" v-b-tooltip.hover :title="scope.item.worklogId">
           <b-icon icon="cloud-check" />
         </span>
-        <span v-else v-b-tooltip.hover :title="$t('notStored')">
-          <b-icon icon="exclamation-octagon-fill" />
-        </span>
       </template>
       <template #cell(hours)="scope">
         {{ parseFloat(scope.item.hours).toFixed(2) }}
@@ -295,7 +292,7 @@ export default defineComponent({
 
       const fields: any[] = ['customer', 'date'];
 
-      if (employee.value?.isAdmin) {
+      if (store.state.employee.employee?.isAdmin) {
         fields.push('worklogId')
       }
 

--- a/components/reports/date-reports.vue
+++ b/components/reports/date-reports.vue
@@ -9,6 +9,8 @@ en:
   approvedBy: "Approved by"
   date: "Date"
   selectProjects: "Select projects"
+  worklogId: "Synced"
+  notStored: "The worklog has not been stored in Bridge. Possibly due to a missing contract at the time of writing."
 nl:
   customer: "Klant"
   print: "Afdrukken"
@@ -19,6 +21,8 @@ nl:
   approvedBy: "Goedgekeurd door"
   date: "Datum"
   selectProjects: "Selecteer projecten"
+  worklogId: "Synced"
+  notStored: "Deze uren zijn niet opgeslagen in Bridge. Mogelijk vanwege het gebrek van een contract ten tijden van invoer."
 </i18n>
 
 <template>
@@ -122,6 +126,7 @@ nl:
         </b-form-checkbox>
       </b-col>
     </b-row>
+
     <b-table
       responsive
       striped
@@ -130,7 +135,7 @@ nl:
       sort-by="date"
       :sort-desc="true"
       :items="reportItems"
-      :fields="['customer', 'date', 'hours']"
+      :fields="reportFields"
       foot-clone
       show-empty
     >
@@ -149,6 +154,14 @@ nl:
       </template>
       <template #cell(date)="scope">
         {{ formatDate(scope.item.date) }}
+      </template>
+      <template #cell(worklogId)="scope">
+        <span v-if="scope.item.worklogId" v-b-tooltip.hover :title="scope.item.worklogId">
+          <b-icon icon="cloud-check" />
+        </span>
+        <span v-else v-b-tooltip.hover :title="$t('notStored')">
+          <b-icon icon="exclamation-octagon-fill" />
+        </span>
       </template>
       <template #cell(hours)="scope">
         {{ parseFloat(scope.item.hours).toFixed(2) }}
@@ -278,6 +291,19 @@ export default defineComponent({
       }
     );
 
+    const reportFields = computed(() => {
+
+      const fields: any[] = ['customer', 'date'];
+
+      if (employee.value?.isAdmin) {
+        fields.push('worklogId')
+      }
+
+      fields.push('hours');
+
+      return fields;
+    })
+
     const reportItems = computed(() => {
       let filteredRecords = store.state.records.timeRecords;
 
@@ -345,6 +371,7 @@ export default defineComponent({
     return {
       employee,
       formatDate,
+      reportFields,
       reportItems,
       onlyBillable,
       projectOptions,


### PR DESCRIPTION
# Changes

## Added

New synced column on the worksheet table on the insights page is added to indicate whether it has been put into Bridge.

## Changed

The icon that previously indicated that a worksheet has been put in Bridge, has been updated to `cloud-check` https://icons.getbootstrap.com/icons/cloud-check/

## How to test

Visit the insights page. As admin you should see the new Synced column.
