### PR TITLE
fix: set default empty array also after getWorkScheme API request

### DIFF
--- a/components/records/weekly-timesheet.vue
+++ b/components/records/weekly-timesheet.vue
@@ -335,7 +335,7 @@ export default defineComponent({
       workWeek: WeekDate[],
       checkOwn: boolean = true
     ): Promise<WorkScheme[]> => {
-      let workScheme: WorkScheme[] = [];
+      let workScheme: WorkScheme[] | undefined = [];
       const isOwnTimesheet = store.state.employee.employee?.id === employee.id;
 
       if (sheet.status === recordStatus.NEW && (!checkOwn || isOwnTimesheet)) {
@@ -354,9 +354,9 @@ export default defineComponent({
           }
         }
       } else {
-        workScheme = sheet.workscheme || [];
+        workScheme = sheet.workscheme;
       }
-      return workScheme
+      return workScheme || [];
     };
 
     const refreshLeave = async () => {


### PR DESCRIPTION
# Changes

## Related issues

https://github.com/FrontMen/fm-hours/issues/811

## Changed

Setting an empty array as default value also affecting getWorkScheme API call, since it was undefined and the consequent helper functions were looking for an array.

## How to test

Not sure how and when it happens that a workScheme can be empty (maybe missing info in Firebase?), but that's the problem I was experiencing myself.
