### PR TITLE
refactor/Call router.push once on logout

### DIFF
--- a/components/records/weekly-timesheet.vue
+++ b/components/records/weekly-timesheet.vue
@@ -346,7 +346,7 @@ export default defineComponent({
           showBridgeError.value = false;
         } catch (error) {
           if (error instanceof AxiosError && error.response?.status === 401) {
-            await logout();
+            store.dispatch('auth/logout');
           } else {
             showBridgeError.value = true;
           }
@@ -362,10 +362,6 @@ export default defineComponent({
 
       timesheet.value.workScheme = await getWorkScheme(timesheet.value.info, timesheet.value.week, false);
     }
-
-    const logout = () => {
-      store.dispatch('auth/logout');
-    };
 
     const saveRecords = async () => {
       if (!employee) return;

--- a/components/records/weekly-timesheet.vue
+++ b/components/records/weekly-timesheet.vue
@@ -121,7 +121,6 @@ import {
   PropType,
   ref,
   useContext,
-  useRouter,
   useStore,
 } from "@nuxtjs/composition-api";
 import {startOfISOWeek} from "date-fns";
@@ -161,9 +160,8 @@ export default defineComponent({
     }
   },
   setup({employee, year, week}: { employee: Employee, year: number, week: number }) {
-    const {i18n, app, localePath} = useContext();
+    const {i18n, app} = useContext();
     const store = useStore<RootStoreState>();
-    const router = useRouter();
 
     const showWeekends = ref<boolean>(JSON.parse(localStorage.getItem('showWeekends')!) || false);
 
@@ -365,9 +363,8 @@ export default defineComponent({
       timesheet.value.workScheme = await getWorkScheme(timesheet.value.info, timesheet.value.week, false);
     }
 
-    const logout = async () => {
-      const authState = await store.dispatch('auth/logout');
-      if (authState) router.push(localePath('/login'));
+    const logout = () => {
+      store.dispatch('auth/logout');
     };
 
     const saveRecords = async () => {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -14,23 +14,18 @@ import {
   computed,
   defineComponent,
   useStore,
-  useRouter,
-  useContext
 } from '@nuxtjs/composition-api';
 
 export default defineComponent({
   middleware: ['isAuthenticated', 'checkEmployee'],
   setup() {
     const store = useStore<RootStoreState>();
-    const router = useRouter();
-    const {localePath} = useContext();
 
     const user = computed(() => store.state.auth.user);
     const employee = computed(() => store.state.employee.employee);
 
-    const logout = async () => {
-      const authState = await store.dispatch('auth/logout');
-      if (authState) router.push(localePath('/login'));
+    const logout = () => {
+      store.dispatch('auth/logout');
     };
 
     return {

--- a/store/auth/actions.ts
+++ b/store/auth/actions.ts
@@ -22,7 +22,8 @@ const actions: ActionTree<AuthStoreState, RootStoreState> = {
     await this.$fire.auth.signOut();
     commit('setLoading', false);
     commit('resetUser');
-    return true;
+    // @ts-ignore
+    this.$router.push(this.localePath('/login'));
   },
 
   /**
@@ -42,11 +43,7 @@ const actions: ActionTree<AuthStoreState, RootStoreState> = {
         headers: {Authorization: user?.samlToken || ''},
       });
     } catch {
-      const authState = await dispatch('logout');
-      if (authState) {
-        // @ts-ignore
-        this.$router.push(this.localePath('/login'));
-      }
+      dispatch('logout');
     }
 
     await dispatch('employee/get', {}, {root: true});

--- a/store/auth/actions.ts
+++ b/store/auth/actions.ts
@@ -22,8 +22,7 @@ const actions: ActionTree<AuthStoreState, RootStoreState> = {
     await this.$fire.auth.signOut();
     commit('setLoading', false);
     commit('resetUser');
-    // @ts-ignore
-    this.$router.push(this.localePath('/login'));
+    this.$router.push(this.app.localePath('/login'));
   },
 
   /**


### PR DESCRIPTION
# Changes

## Changed

Before we were calling `router.push()` manually every time we dispatched a logout action every where this was done. I've put it within the action itself and removed the redundancy.

## How to test

Try to log out across all possible scenarios.
