### PR TITLE
fix: only update admins if we need to

### DIFF
--- a/services/employees-service.ts
+++ b/services/employees-service.ts
@@ -98,12 +98,17 @@ export default class EmployeesService {
     delete newEmployee.id;
 
     let list = await this.getAdminEmails();
+    const totalAdmins = list.length;
     if (isAdmin && !list.includes(newEmployee.email)) {
       list.push(newEmployee.email);
     } else if (!isAdmin) {
       list = list.filter(a => a !== newEmployee.email);
     }
-    await this.updateAdminEmails(list);
+
+    // Check if the the list of admins changed
+    if (list.length !== totalAdmins) {
+      await this.updateAdminEmails(list);
+    }
 
     return await this.fire.firestore
       .collection(Collections.EMPLOYEES)


### PR DESCRIPTION
Recently I made a change that we add the isAdmin prop to the employee in the frontend while it's 2 collections in firestore.

When a new employee logs in for the first time we retrieve a bridgeUid and we update the employee with this new ID.

This is the only time that a non-admin edits an employee.
Because we were always updating the admin list, without even checking if it changed, a non-admin would try to update the admin collection.

This results in a permission violation based on the firestore security rules.