### PR TITLE
fix: teams not being sorted alphabetical

### DIFF
--- a/services/teams-service.ts
+++ b/services/teams-service.ts
@@ -14,13 +14,15 @@ export default class TeamsService {
   async getAll(): Promise<Team[]> {
     const snapshot = await this.fire.firestore.collection(Collections.TEAMS).get();
 
-    return snapshot.docs.map((res: any) => {
-      const team = res.data();
-      return {
-        id: res.id,
-        ...team,
-      } as Team;
-    });
+    return snapshot.docs
+      .map((res: any) => {
+        const team = res.data();
+        return {
+          id: res.id,
+          ...team,
+        } as Team;
+      })
+      .sort((a, b) => a.name.localeCompare(b.name));
   }
 
   async getById(id: string): Promise<Team | undefined> {


### PR DESCRIPTION
# Changes

## Related issues

fixes: #848

## Added

Sorting of teams when retrieving them for the team dropdown in Timesheet page.

## Removed

N/A

## Changed

Added sort to teams get / map.

## How to test

Go to `/admin/timesheets` and check out the teams in dropdown are now alphabetically sort

## Screenshots

<table>
<tr>
	<td>OLD</td>
	<td>NEW</td>
	</tr>
<tr>
	<td>
<img src="https://user-images.githubusercontent.com/802221/212166139-76fdd339-813a-4af8-8cdc-90712cbdd099.png"/>
</td>
	<td>
<img src="https://user-images.githubusercontent.com/802221/212165757-bf2b4f62-823f-405d-b46b-c4bca2c10e9d.png" />
</td>
</tr>
</table>
